### PR TITLE
Fix: Snapshot Parameter Keys on LoRA Remove

### DIFF
--- a/stable_audio_3/models/lora/model.py
+++ b/stable_audio_3/models/lora/model.py
@@ -357,7 +357,7 @@ def apply_lora(layer, register=True, merge=False, lora_config=default_lora_confi
                 parametrize.register_parametrization(layer, attr_name, parametrization(layer), unsafe=True)
     else:  # this will remove all parametrizations, use with caution
         if hasattr(layer, "parametrizations"):
-            for attr_name in layer.parametrizations.keys():
+            for attr_name in list(layer.parametrizations.keys()):
                 parametrize.remove_parametrizations(layer, attr_name, leave_parametrized=merge)
 
 


### PR DESCRIPTION
Without this change, it is possible to have the dictionary change size during iteration while removing LoRA, causing errors.