### PR TITLE
mlx: gradio web UI with all generation modes

### DIFF
--- a/optimized/mlx/.gitignore
+++ b/optimized/mlx/.gitignore
@@ -10,3 +10,4 @@
 # Python bytecode caches
 __pycache__/
 *.pyc
+output/gradio/

--- a/optimized/mlx/README.md
+++ b/optimized/mlx/README.md
@@ -122,9 +122,11 @@ python scripts/sa3_mlx.py --prompt "..." --dit medium --decoder same-l
 ./sa3-gradio --dit medium     # initial model (switchable in the UI)
 ```
 
-Every generation mode is wired: text-to-audio, CFG + negative prompt (with APG),
-audio-to-audio (upload init audio + σmax slider), and inpainting (upload +
-`START,END` seconds range). Each clip renders with a 3-band tinted stereo mel
+Every generation mode is wired: text-to-audio, CFG 0–10 (0 = the negative prompt
+takes over, 0.5 = halfway between both prompts, >1 = extrapolate), audio-to-audio
+(guide audio + σmax slider), and inpainting (separate reference audio + start/end
+range sliders) — a2a and inpainting combine, so an inpainted span can regenerate
+from the guide audio instead of noise. Each clip renders with a 3-band tinted stereo mel
 spectrogram (bass=red / mid=green / high=blue). Models hot-swap from the
 dropdowns and cache in unified memory, so switching back is instant; WAVs land
 in `output/gradio/`. The UI needs two extra packages (`gradio`, `pillow`) —

--- a/optimized/mlx/README.md
+++ b/optimized/mlx/README.md
@@ -114,6 +114,22 @@ uv run python scripts/sa3_mlx.py --prompt "..." --dit medium --decoder same-l
 python scripts/sa3_mlx.py --prompt "..." --dit medium --decoder same-l
 ```
 
+## Web UI (gradio)
+
+```bash
+./sa3-gradio                  # public gradio.live share link by default
+./sa3-gradio --no-share       # local-only (http://127.0.0.1:7860)
+./sa3-gradio --dit medium     # initial model (switchable in the UI)
+```
+
+Every generation mode is wired: text-to-audio, CFG + negative prompt (with APG),
+audio-to-audio (upload init audio + σmax slider), and inpainting (upload +
+`START,END` seconds range). Each clip renders with a 3-band tinted stereo mel
+spectrogram (bass=red / mid=green / high=blue). Models hot-swap from the
+dropdowns and cache in unified memory, so switching back is instant; WAVs land
+in `output/gradio/`. The UI needs two extra packages (`gradio`, `pillow`) —
+`./sa3-gradio` offers to install them into `.venv` on first run.
+
 ## Speed & memory
 
 Measured on **M1 8 GB** (the slowest M-chip). Newer chips are faster —

--- a/optimized/mlx/requirements-gradio.txt
+++ b/optimized/mlx/requirements-gradio.txt
@@ -1,3 +1,4 @@
 # Extras for the gradio web UI (./sa3-gradio) — not needed by the CLI.
 gradio>=4.0
 pillow>=10.0
+soundfile>=0.12   # decode mp3/flac/24-bit/48kHz uploads without ffmpeg

--- a/optimized/mlx/requirements-gradio.txt
+++ b/optimized/mlx/requirements-gradio.txt
@@ -1,0 +1,3 @@
+# Extras for the gradio web UI (./sa3-gradio) — not needed by the CLI.
+gradio>=4.0
+pillow>=10.0

--- a/optimized/mlx/sa3-gradio
+++ b/optimized/mlx/sa3-gradio
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Shortcut for running scripts/sa3_gradio.py with the project .venv.
+# All args pass through unchanged.
+#
+# Examples:
+#   ./sa3-gradio                            # sm-music + same-s, public share link
+#   ./sa3-gradio --dit medium
+#   ./sa3-gradio --no-share                 # local-only
+#   ./sa3-gradio --help
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${SCRIPT_DIR}/.venv/bin/python"
+
+if [ ! -x "$PY" ]; then
+  echo "No .venv found — run ./install.sh first."
+  exit 1
+fi
+
+# gradio + pillow are UI-only extras, not part of the base requirements.
+if ! "$PY" -c "import gradio, PIL" >/dev/null 2>&1; then
+  echo "The gradio UI needs two extra packages (gradio, pillow)."
+  read -r -p "Install them into .venv now? [Y/n] " ans
+  case "${ans:-Y}" in
+    [Yy]*)
+      if command -v uv >/dev/null 2>&1; then
+        uv pip install -p "$PY" -r "${SCRIPT_DIR}/requirements-gradio.txt"
+      else
+        "$PY" -m pip install -r "${SCRIPT_DIR}/requirements-gradio.txt"
+      fi
+      ;;
+    *) echo "Aborted — install manually: uv pip install -p .venv/bin/python -r requirements-gradio.txt"; exit 1 ;;
+  esac
+fi
+
+exec "$PY" "${SCRIPT_DIR}/scripts/sa3_gradio.py" "$@"

--- a/optimized/mlx/sa3-gradio
+++ b/optimized/mlx/sa3-gradio
@@ -16,9 +16,9 @@ if [ ! -x "$PY" ]; then
   exit 1
 fi
 
-# gradio + pillow are UI-only extras, not part of the base requirements.
-if ! "$PY" -c "import gradio, PIL" >/dev/null 2>&1; then
-  echo "The gradio UI needs two extra packages (gradio, pillow)."
+# gradio + pillow + soundfile are UI-only extras, not part of the base requirements.
+if ! "$PY" -c "import gradio, PIL, soundfile" >/dev/null 2>&1; then
+  echo "The gradio UI needs a few extra packages (gradio, pillow, soundfile)."
   read -r -p "Install them into .venv now? [Y/n] " ans
   case "${ans:-Y}" in
     [Yy]*)

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -1,0 +1,473 @@
+"""SA3 MLX — gradio web UI (Apple Silicon).
+
+The MLX sibling of optimized/tensorRT/scripts/sa3_gradio.py, with every
+generation mode wired (the TRT one only exposes text-to-audio):
+  - Model picker: sm-music / sm-sfx / medium (hot-swap; models cache in unified
+    memory, LRU-evicted — first switch loads weights, subsequent instant)
+  - CFG + negative prompt (batched CFG with APG, same math as sa3_mlx.py)
+  - Audio-to-audio: upload init audio + σmax slider
+  - Inpainting: init audio + "START,END" seconds range (paste-back guaranteed
+    bit-exact outside the range)
+  - Spectrogram display: 3-band tinted stereo mel spectrogram (numpy port —
+    no torch), rendered inline alongside the audio
+
+Launch:
+    ./sa3-gradio                  # share=True by default, sm-music + same-s
+    ./sa3-gradio --dit medium
+    ./sa3-gradio --no-share       # local-only
+"""
+from __future__ import annotations
+import argparse
+import base64
+import math
+import sys
+import time
+import uuid
+import wave
+from pathlib import Path
+
+import numpy as np
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO = SCRIPTS_DIR.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import mlx.core as mx  # noqa: E402
+
+from sa3_mlx import (  # noqa: E402
+    DIT_CHOICES, DECODER_CHOICES, ENCODER_CHOICES, T5GEMMA_NPZ_REL,
+    SAMPLE_RATE, SAMPLES_PER_LATENT,
+    load_dit, load_decoder, load_encoder, read_wav, patch_audio, _free_to_pool,
+)
+from models.defs.sa3_pipeline import (  # noqa: E402
+    apply_prompt_padding, build_pingpong_schedule, sample_flow_pingpong,
+    patched_decode, load_conditioner_from_npz,
+)
+from models.defs.t5gemma_mlx import T5Gemma  # noqa: E402
+from weights import ensure_local  # noqa: E402
+from spec import render_spectrogram_png  # noqa: E402
+
+OUTPUT_DIR = REPO / "output" / "gradio"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+KEEP_RECENT_N = 20
+MIN_SIGMA = 0.01
+DEFAULT_DECODERS = {name: cfg["default_decoder"] for name, cfg in DIT_CHOICES.items()}
+
+
+def _prune_old_outputs():
+    wavs = sorted(OUTPUT_DIR.glob("*.wav"), key=lambda p: p.stat().st_mtime, reverse=True)
+    for old in wavs[KEEP_RECENT_N:]:
+        try:
+            old.unlink()
+        except OSError:
+            pass
+
+
+def _save_wav(pcm_int16, out_path):
+    """pcm_int16: (T, 2) int16 interleaved."""
+    with wave.open(str(out_path), "wb") as w:
+        w.setnchannels(2)
+        w.setsampwidth(2)
+        w.setframerate(SAMPLE_RATE)
+        w.writeframes(pcm_int16.tobytes())
+
+
+# ── Model caches (unified memory; ~0.9-2.8 GB per DiT, 0.2-1.7 GB per codec) ──
+# The MLX DiT bakes RoPE/mask lengths at load, so the DiT cache key includes
+# T_lat. Everything else is length-independent and cached by name.
+_t5: T5Gemma | None = None
+_cond_cache: dict[str, tuple] = {}                       # dit -> (padding_emb, secs_embedder)
+_dit_cache: dict[tuple[str, int], object] = {}           # (dit, T_lat) -> model
+_dit_lru: list[tuple[str, int]] = []
+_DIT_CACHE_MAX = 2
+_dec_cache: dict[str, tuple] = {}                        # decoder -> (model, chunk_fn, chunk_cfg)
+_enc_cache: dict[str, tuple] = {}                        # decoder -> (model, pad_modulo)
+
+
+def get_t5() -> T5Gemma:
+    global _t5
+    if _t5 is None:
+        _t5 = T5Gemma.from_npz(str(ensure_local(T5GEMMA_NPZ_REL)))
+    return _t5
+
+
+def get_conditioner(dit_name: str):
+    if dit_name not in _cond_cache:
+        _cond_cache[dit_name] = load_conditioner_from_npz(
+            str(ensure_local(DIT_CHOICES[dit_name]["ckpt"])), prefix="cond.")
+    return _cond_cache[dit_name]
+
+
+def get_dit(dit_name: str, T_lat: int, dtype):
+    key = (dit_name, T_lat)
+    if key in _dit_cache:
+        if key in _dit_lru:
+            _dit_lru.remove(key)
+        _dit_lru.append(key)
+        return _dit_cache[key], 0.0
+    while len(_dit_cache) >= _DIT_CACHE_MAX:
+        oldest = _dit_lru.pop(0)
+        print(f"  ← LRU-evicting DiT {oldest}")
+        _dit_cache.pop(oldest, None)
+        _free_to_pool()
+    t0 = time.time()
+    model, _ = load_dit(dit_name, T_lat=T_lat, dtype=dtype)
+    load_ms = (time.time() - t0) * 1000
+    _dit_cache[key] = model
+    _dit_lru.append(key)
+    return model, load_ms
+
+
+def get_decoder(decoder_name: str):
+    if decoder_name not in _dec_cache:
+        _dec_cache[decoder_name] = load_decoder(decoder_name, mx.float32)
+    return _dec_cache[decoder_name]
+
+
+def get_encoder(decoder_name: str):
+    if decoder_name not in _enc_cache:
+        _enc_cache[decoder_name] = load_encoder(decoder_name, mx.float32)
+    return _enc_cache[decoder_name]
+
+
+# ── One full generation (mirrors sa3_mlx.py main(), all modes) ─────────────
+def run_generation(dit_name: str, decoder_name: str, prompt: str,
+                   negative_prompt: str, seconds: float, steps: int,
+                   seed: int, cfg: float, apg: float, sigma_max: float,
+                   init_audio_path: str | None, inpaint_range_sec):
+    """Returns (audio_np (2,T) float32, timings dict)."""
+    t = {}
+    dtype = mx.float16   # MLX canonical DiT dtype
+    T_lat = max(1, math.ceil(seconds * SAMPLE_RATE / SAMPLES_PER_LATENT))
+
+    # 1. T5Gemma
+    t0 = time.time()
+    enc = get_t5()
+    embeds, mask = enc.encode([prompt], max_len=256)
+    mx.eval(embeds, mask)
+    t["t5_ms"] = (time.time() - t0) * 1000
+
+    # 2. Conditioning
+    t0 = time.time()
+    padding_emb, secs_embedder = get_conditioner(dit_name)
+    embeds = embeds.astype(dtype)
+    embeds_padded = apply_prompt_padding(embeds, mask, padding_emb.astype(dtype))
+    seconds_embed = secs_embedder(seconds).astype(dtype)
+    cross_attn = mx.concatenate([embeds_padded, seconds_embed], axis=1)
+    global_cond = seconds_embed[:, 0, :]
+    null_cross_attn = None
+    if cfg != 1.0:
+        if negative_prompt and negative_prompt.strip():
+            neg_embeds, neg_mask = enc.encode([negative_prompt.strip()], max_len=256)
+            mx.eval(neg_embeds, neg_mask)
+            neg_padded = apply_prompt_padding(neg_embeds.astype(dtype), neg_mask,
+                                              padding_emb.astype(dtype))
+            null_cross_attn = mx.concatenate([neg_padded, seconds_embed], axis=1)
+        else:
+            null_cross_attn = mx.zeros_like(cross_attn)
+        mx.eval(null_cross_attn)
+    mx.eval(cross_attn, global_cond)
+    t["cond_ms"] = (time.time() - t0) * 1000
+
+    # 3a. (a2a / inpaint) encode init audio → latents
+    init_latents = None
+    if init_audio_path:
+        t0 = time.time()
+        enc_model, pad_mod = get_encoder(decoder_name)
+        enc_T_lat = T_lat
+        if (T_lat * 16) % pad_mod != 0:
+            enc_T_lat = math.ceil((T_lat * 16) / pad_mod) * pad_mod // 16
+        target_samples = enc_T_lat * SAMPLES_PER_LATENT
+        audio_np = read_wav(init_audio_path)
+        if audio_np.shape[-1] >= target_samples:
+            audio_np = audio_np[:, :target_samples]
+        else:
+            audio_np = np.pad(audio_np, ((0, 0), (0, target_samples - audio_np.shape[-1])))
+        patches_np = patch_audio(audio_np[None, ...], patch_size=256)
+        init_latents = enc_model(mx.array(patches_np))[..., :T_lat]
+        mx.eval(init_latents)
+        init_latents = init_latents.astype(dtype)
+        t["enc_ms"] = (time.time() - t0) * 1000
+
+    # 3b. DiT + pingpong sample
+    dit_model, t["dit_load_ms"] = get_dit(dit_name, T_lat, dtype)
+    sigmas = build_pingpong_schedule(steps, sigma_max=sigma_max, use_logsnr_shift=True)
+
+    key = mx.random.key(seed)
+    pure_noise = mx.random.normal((1, 256, T_lat), dtype=dtype, key=key)
+    inpaint_lat = None
+    if inpaint_range_sec is not None:
+        s0 = max(0, int(round(inpaint_range_sec[0] * SAMPLE_RATE / SAMPLES_PER_LATENT)))
+        s1 = min(T_lat, int(round(inpaint_range_sec[1] * SAMPLE_RATE / SAMPLES_PER_LATENT)))
+        inpaint_lat = (s0, s1)
+    if init_latents is not None and inpaint_lat is None:
+        noise = init_latents * (1.0 - sigma_max) + pure_noise * sigma_max
+    else:
+        noise = pure_noise
+    mx.eval(noise)
+
+    local_add_cond = None
+    paste_back = None
+    if inpaint_lat is not None:
+        s0, s1 = inpaint_lat
+        mask_np = np.ones((1, 1, T_lat), dtype=np.float32)
+        mask_np[:, :, s0:s1] = 0.0
+        keep = mx.array(mask_np)
+        masked_input = init_latents.astype(mx.float32) * keep
+        local_add_cond = mx.concatenate([keep, masked_input], axis=1).transpose(0, 2, 1).astype(dtype)
+        paste_back = (init_latents, keep)
+
+    def model_fn(x, tt):
+        if cfg == 1.0:
+            return dit_model(x, tt, cross_attn, global_cond, local_add_cond=local_add_cond)
+        x2 = mx.concatenate([x, x], axis=0)
+        t2 = mx.concatenate([tt, tt], axis=0)
+        cross2 = mx.concatenate([cross_attn, null_cross_attn], axis=0)
+        global2 = mx.concatenate([global_cond, global_cond], axis=0)
+        lac2 = None if local_add_cond is None else mx.concatenate([local_add_cond, local_add_cond], axis=0)
+        v_batched = dit_model(x2, t2, cross2, global2, local_add_cond=lac2)
+        cond_v, uncond_v = mx.split(v_batched, 2, axis=0)
+        sigma = tt.reshape(-1, 1, 1).astype(mx.float32)
+        cond_d = x.astype(mx.float32) - cond_v.astype(mx.float32) * sigma
+        uncond_d = x.astype(mx.float32) - uncond_v.astype(mx.float32) * sigma
+        diff = cond_d - uncond_d
+        if apg <= 0.0:
+            cfg_diff = diff
+        else:
+            norm = mx.sqrt((cond_d * cond_d).sum(axis=(-2, -1), keepdims=True))
+            unit = cond_d / mx.maximum(norm, 1e-8)
+            parallel = (diff * unit).sum(axis=(-2, -1), keepdims=True) * unit
+            diff_orth = diff - parallel
+            cfg_diff = diff_orth if apg >= 1.0 else (apg * diff_orth + (1.0 - apg) * diff)
+        cfg_d = cond_d + (cfg - 1.0) * cfg_diff
+        cfg_v = (x.astype(mx.float32) - cfg_d) / sigma
+        return cfg_v.astype(x.dtype)
+
+    t0 = time.time()
+    latents = sample_flow_pingpong(model_fn, noise, sigmas, seed=seed + 1,
+                                   paste_back=paste_back)
+    mx.eval(latents)
+    t["sample_ms"] = (time.time() - t0) * 1000
+
+    # 4. Decode (fp32 codec; parity-aware chunk dispatch from sa3_mlx.py)
+    t0 = time.time()
+    decoder, chunk_fn, (chunk, ovl) = get_decoder(decoder_name)
+    latents_fp32 = latents.astype(mx.float32)
+    kernel = chunk + 2 * ovl
+    if T_lat > kernel:
+        patches = chunk_fn(decoder, latents_fp32, chunk, ovl)
+    elif T_lat % 2 == 0:
+        patches = decoder(latents_fp32)
+    elif T_lat > 6:
+        patches = chunk_fn(decoder, latents_fp32, 2, 2)
+    else:
+        latents_even = mx.concatenate([latents_fp32, latents_fp32[..., -1:]], axis=-1)
+        patches = decoder(latents_even)[..., : T_lat * 16]
+    mx.eval(patches)
+    t["decode_ms"] = (time.time() - t0) * 1000
+
+    # 5. Unpatch + trim
+    audio = patched_decode(patches, patch_size=256, channels=2)
+    mx.eval(audio)
+    audio_np = np.array(audio.astype(mx.float32))[0]
+    requested = int(round(seconds * SAMPLE_RATE))
+    if audio_np.shape[-1] > requested:
+        audio_np = audio_np[..., :requested]
+
+    t["T_lat"] = T_lat
+    t["samples"] = audio_np.shape[-1]
+    t["inference_ms"] = sum(t.get(k, 0) for k in
+                            ("t5_ms", "cond_ms", "enc_ms", "dit_load_ms", "sample_ms", "decode_ms"))
+    t["realtime"] = (audio_np.shape[-1] / SAMPLE_RATE) / max(t["inference_ms"] / 1000, 1e-9)
+    return audio_np, t
+
+
+# ── Gradio UI ──────────────────────────────────────────────────────────────
+def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
+             default_seconds: float, default_steps: int):
+    import gradio as gr
+    import random as _random
+
+    # Pre-warm the initial pipeline so the first click is fast.
+    warm_T = max(1, math.ceil(default_seconds * SAMPLE_RATE / SAMPLES_PER_LATENT))
+    print(f"  pre-warming {initial_dit}+{initial_decoder} (T_lat={warm_T})...")
+    get_t5(); get_conditioner(initial_dit)
+    get_dit(initial_dit, warm_T, mx.float16); get_decoder(initial_decoder)
+
+    def on_dit_change(dit_name):
+        return gr.update(value=DEFAULT_DECODERS.get(dit_name, "same-s"))
+
+    def generate(dit_name, decoder_name, prompt, negative_prompt,
+                 seconds, steps, seed_text, cfg, apg, sigma_max,
+                 init_audio, inpaint_text):
+        err = lambda m: ("", "", "", f"<span style='color:#f88'>{m}</span>")
+        prompt = (prompt or "").strip()
+        try:
+            seed = int(seed_text.strip()) if seed_text and seed_text.strip() else _random.randint(0, 2**31 - 1)
+        except ValueError:
+            return err("error: seed must be an integer")
+        if sigma_max < MIN_SIGMA:
+            return err(f"error: σmax must be ≥ {MIN_SIGMA} (rf_denoiser is undefined at t≈0)")
+        inpaint_range = None
+        if inpaint_text and inpaint_text.strip():
+            if not init_audio:
+                return err("error: inpaint range requires init audio")
+            try:
+                s_str, e_str = inpaint_text.split(",")
+                inpaint_range = (float(s_str), float(e_str))
+            except ValueError:
+                return err(f"error: inpaint range must be 'START,END' seconds, got {inpaint_text!r}")
+            if not (0 <= inpaint_range[0] < inpaint_range[1] <= seconds):
+                return err(f"error: need 0 ≤ start < end ≤ {seconds}s")
+
+        mode = ("inpaint" if inpaint_range else
+                "audio-to-audio" if init_audio else "text-to-audio")
+        try:
+            audio_np, t = run_generation(
+                dit_name, decoder_name, prompt, negative_prompt or "",
+                float(seconds), int(steps), seed, float(cfg), float(apg),
+                float(sigma_max), init_audio or None, inpaint_range)
+        except Exception as e:
+            return err(f"error: {type(e).__name__}: {e}")
+        if not np.isfinite(audio_np).all():
+            return err("error: model produced non-finite audio (try a higher σmax or different seed)")
+
+        pcm = (np.clip(audio_np, -1, 1) * 32767.0).astype(np.int16).T   # (T, 2)
+        out_path = OUTPUT_DIR / f"sa3-{uuid.uuid4().hex[:10]}.wav"
+        _save_wav(pcm, out_path)
+        _prune_old_outputs()
+        b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
+        audio_html = (
+            f'<audio controls autoplay style="width:100%" '
+            f'src="data:audio/wav;base64,{b64}"></audio>'
+            f'<div style="font-size:0.85em; margin-top:4px; color:#888">'
+            f'{out_path.stat().st_size/1e6:.1f} MB · {mode} · right-click to download</div>'
+        )
+        try:
+            spec_png = render_spectrogram_png(pcm, sample_rate=SAMPLE_RATE,
+                                              width=1200, height=240)
+            spec_b64 = base64.b64encode(spec_png).decode("ascii")
+            spec_html = (
+                f'<img src="data:image/png;base64,{spec_b64}" '
+                f'style="width:100%; image-rendering:pixelated; border:1px solid #333" '
+                f'alt="spectrogram"/>'
+                f'<div style="font-size:0.75em; color:#666; margin-top:2px">'
+                f'3-band tinted stereo mel · red=bass / green=mid / blue=high · L top, R bottom</div>'
+            )
+        except Exception as e:
+            spec_html = f"<span style='color:#fa3'>spectrogram failed: {type(e).__name__}: {e}</span>"
+
+        load_note = (f"DiT-load {t['dit_load_ms']:.0f} ms ·&nbsp; "
+                     if t.get("dit_load_ms", 0) > 100 else "")
+        enc_note = f"encode {t['enc_ms']:.0f} ms ·&nbsp; " if t.get("enc_ms") else ""
+        cfg_note = f"cfg {cfg} (apg {apg}) ·&nbsp; " if cfg != 1.0 else ""
+        timing_html = (
+            f"{load_note}{enc_note}{cfg_note}"
+            f"<b>Inference</b>: {t['inference_ms']:.0f} ms "
+            f"<span style='color:#888'>(t5={t['t5_ms']:.0f} · sample={t['sample_ms']:.0f} · "
+            f"decode={t['decode_ms']:.0f})</span> ·&nbsp; "
+            f"<b>{t['realtime']:.1f}× realtime</b> ·&nbsp; "
+            f"<b>seed</b>: <code>{seed}</code> ·&nbsp; "
+            f"<b>T_lat</b>: {t['T_lat']} ·&nbsp; <b>samples</b>: {t['samples']}"
+        )
+        return audio_html, spec_html, timing_html, ""
+
+    with gr.Blocks(title="SA3 MLX") as demo:
+        gr.Markdown(
+            "# SA3 MLX — Apple Silicon\n"
+            "All modes wired: text-to-audio, CFG + negative prompt, audio-to-audio "
+            "(upload + σmax), inpainting (upload + range). Models cache in unified "
+            "memory — first use of a model loads weights, subsequent runs are instant."
+        )
+        with gr.Row():
+            with gr.Column(scale=3):
+                with gr.Row():
+                    dit_dd = gr.Dropdown(label="DiT model", choices=list(DIT_CHOICES.keys()),
+                                         value=initial_dit, scale=1)
+                    decoder_dd = gr.Dropdown(label="Decoder (codec)",
+                                             choices=list(DECODER_CHOICES.keys()),
+                                             value=initial_decoder, scale=1)
+                prompt = gr.Textbox(label="Prompt", lines=2,
+                                    placeholder="e.g. 'Impending tribal, epic orchestral buildup'")
+                with gr.Row():
+                    seconds = gr.Slider(label="Seconds", minimum=1, maximum=120,
+                                        value=default_seconds, step=1)
+                    steps = gr.Slider(label="Steps", minimum=1, maximum=16,
+                                      value=default_steps, step=1)
+                seed = gr.Textbox(label="Seed (optional, blank = random)",
+                                  max_lines=1, value="")
+                generate_btn = gr.Button("Generate", variant="primary", size="lg")
+
+                with gr.Accordion("CFG / negative prompt", open=False):
+                    cfg = gr.Slider(label="CFG scale (1.0 = off)", minimum=1.0,
+                                    maximum=10.0, value=1.0, step=0.1)
+                    apg = gr.Slider(label="APG (1 = full orthogonal projection, 0 = vanilla CFG)",
+                                    minimum=0.0, maximum=1.0, value=1.0, step=0.05)
+                    negative_prompt = gr.Textbox(label="Negative prompt (needs CFG > 1)", lines=1)
+
+                with gr.Accordion("Audio-to-audio / inpainting", open=False):
+                    init_audio = gr.Audio(label="Init audio (enables a2a; add a range below for inpainting)",
+                                          type="filepath")
+                    sigma_slider = gr.Slider(label="Init noise level σmax (a2a: 0.4–0.8 typical; 1.0 = ignore init)",
+                                             minimum=0.05, maximum=1.2, value=1.0, step=0.05)
+                    inpaint_text = gr.Textbox(
+                        label="Inpaint range 'START,END' seconds (regenerates just that span; blank = a2a)",
+                        max_lines=1, value="")
+                    gr.Markdown(
+                        "<span style='color:#888; font-size:0.85em'>a2a wants clips ≥ ~20 s "
+                        "(shorter inputs give repetitive latents). Inpainting reads best with "
+                        "CFG ≥ 5 and a contrasting prompt.</span>")
+
+            with gr.Column(scale=2):
+                gr.Markdown("**Audio**")
+                output_audio = gr.HTML()
+                gr.Markdown("**Spectrogram**")
+                output_spec = gr.HTML()
+                timing = gr.HTML()
+                error_box = gr.HTML()
+
+        dit_dd.change(on_dit_change, inputs=[dit_dd], outputs=[decoder_dd])
+        generate_btn.click(generate,
+                           inputs=[dit_dd, decoder_dd, prompt, negative_prompt,
+                                   seconds, steps, seed, cfg, apg, sigma_slider,
+                                   init_audio, inpaint_text],
+                           outputs=[output_audio, output_spec, timing, error_box])
+
+        gr.Markdown(
+            "<p style='color:#888; font-size:0.85em'>"
+            f"WAVs saved under <code>output/gradio/</code> (rotates after {KEEP_RECENT_N} files). "
+            "DiT runs fp16 (MLX canonical), codecs fp32.</p>"
+        )
+
+    demo.queue(max_size=16).launch(share=share, server_name="0.0.0.0",
+                                   prevent_thread_lock=False, show_error=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dit", choices=list(DIT_CHOICES.keys()), default="sm-music",
+                    help="Initial DiT bundle (switchable at runtime)")
+    ap.add_argument("--decoder", choices=list(DECODER_CHOICES.keys()), default=None,
+                    help="Initial decoder. Default: pairs with --dit")
+    ap.add_argument("--default-seconds", type=float, default=30.0,
+                    help="Length to pre-warm the initial DiT at")
+    ap.add_argument("--default-steps", type=int, default=8)
+    ap.add_argument("--share", action=argparse.BooleanOptionalAction, default=True,
+                    help="Create a public gradio.live URL (default on)")
+    args = ap.parse_args()
+
+    if args.decoder is None:
+        args.decoder = DEFAULT_DECODERS[args.dit]
+
+    print(f"\n━━━ SA3 MLX — gradio ━━━")
+    print(f"  initial dit:     {args.dit}")
+    print(f"  initial decoder: {args.decoder}")
+    print(f"  models:          {', '.join(DIT_CHOICES.keys())}  (runtime-switchable)")
+    build_ui(args.dit, args.decoder, share=args.share,
+             default_seconds=args.default_seconds, default_steps=args.default_steps)
+
+
+if __name__ == "__main__":
+    main()

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -730,9 +730,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
     with gr.Blocks(title="SA3 MLX", css="#sa3-promote{display:none !important}") as demo:
         gr.Markdown(
             "# SA3 MLX — Apple Silicon\n"
-            "All modes wired: text-to-audio, CFG + negative prompt, audio-to-audio "
-            "(upload + σmax), inpainting (upload + range). Models cache in unified "
-            "memory — first use of a model loads weights, subsequent runs are instant."
+            "Text-to-audio, CFG + negative prompt, audio-to-audio, inpainting. "
+            "First use of a model loads weights, subsequent runs are cached."
         )
         st = gr.State({"current": None, "queued": None, "history": []})
         with gr.Row():

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -391,11 +391,12 @@ _JS_PLAYHEAD = ("var p=this.closest('.blk').querySelector('.ph');"
                 "if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+'%';")
 # Main-player position ledger (for Hotswap): every timeupdate/play/pause stamps
 # the current position so a freshly swapped-in element can resume exactly there.
-_JS_POS_RECORD = "window._sa3Pos={t:this.currentTime,playing:!this.paused,ts:Date.now()};"
-# Pause events also fire when the old element is REMOVED from the DOM during the
-# swap — that teardown-pause must not overwrite the playing:true stamp, or the
-# new element would think nothing was playing. Only record user pauses.
-_JS_POS_RECORD_PAUSE = f"if(this.isConnected){{{_JS_POS_RECORD}}}"
+# EVERY recorder is guarded on isConnected: when the old element is removed
+# during the swap, the browser fires a teardown pause AND a final timeupdate on
+# the detached element — either would overwrite the playing:true stamp and kill
+# the resume. Detached elements never get to write the ledger.
+_JS_POS_RECORD = ("if(this.isConnected){window._sa3Pos="
+                  "{t:this.currentTime,playing:!this.paused,ts:Date.now()};}")
 # Hotswap resume: if the previous main audio was playing when this one arrived,
 # jump to its position (+ the split-second since the last stamp) and keep going;
 # beyond the new clip's duration -> start at zero. Guarded (hsd) so it applies
@@ -475,7 +476,7 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
         attrs = f'onplay="{_JS_PAUSE_OTHERS}" ontimeupdate="{_JS_PLAYHEAD}"'
     else:
         attrs = (f'onplay="{_JS_PAUSE_OTHERS}{_JS_POS_RECORD}" '
-                 f'onpause="{_JS_POS_RECORD_PAUSE}" '
+                 f'onpause="{_JS_POS_RECORD}" '
                  f'ontimeupdate="{_JS_PLAYHEAD}{_JS_POS_RECORD}"')
     if hotswap and not small:
         attrs += f' data-hs="1" onloadedmetadata="{_JS_HOTSWAP}"'

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -392,12 +392,18 @@ _JS_PLAYHEAD = ("var p=this.closest('.blk').querySelector('.ph');"
 # Main-player position ledger (for Hotswap): every timeupdate/play/pause stamps
 # the current position so a freshly swapped-in element can resume exactly there.
 _JS_POS_RECORD = "window._sa3Pos={t:this.currentTime,playing:!this.paused,ts:Date.now()};"
+# Pause events also fire when the old element is REMOVED from the DOM during the
+# swap — that teardown-pause must not overwrite the playing:true stamp, or the
+# new element would think nothing was playing. Only record user pauses.
+_JS_POS_RECORD_PAUSE = f"if(this.isConnected){{{_JS_POS_RECORD}}}"
 # Hotswap resume: if the previous main audio was playing when this one arrived,
 # jump to its position (+ the split-second since the last stamp) and keep going;
-# beyond the new clip's duration -> start at zero.
-_JS_HOTSWAP = ("if(this.dataset.hs==='1'){var s=window._sa3Pos;"
+# beyond the new clip's duration -> start at zero. Guarded (hsd) so it applies
+# once, on whichever of loadedmetadata/canplay fires first.
+_JS_HOTSWAP = ("if(this.dataset.hs==='1'&&!this.dataset.hsd&&this.duration){"
+               "this.dataset.hsd=1;var s=window._sa3Pos;"
                "if(s&&s.playing){var tt=s.t+(Date.now()-s.ts)/1000;"
-               "this.currentTime=(this.duration&&tt<this.duration)?tt:0;this.play();}}")
+               "this.currentTime=(tt<this.duration)?tt:0;this.play();}}")
 _JS_SEEK = ("var a=this.closest('.blk').querySelector('audio');"
             "var r=this.getBoundingClientRect();"
             "if(a&&a.duration){a.currentTime=(event.clientX-r.left)/r.width*a.duration;a.play();}")
@@ -462,19 +468,25 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
     advance: on ended, hop to the next history item's audio (Auto-play).
     loop: native loop attribute — finished audio restarts (suppresses ended).
     hotswap: main slot only — resume at the previous clip's position on arrival."""
+    # assemble per-event handler bodies (a duplicated attribute name would
+    # silently drop one handler, so each event is emitted exactly once)
+    on_canplay = []
     if small:
         attrs = f'onplay="{_JS_PAUSE_OTHERS}" ontimeupdate="{_JS_PLAYHEAD}"'
     else:
         attrs = (f'onplay="{_JS_PAUSE_OTHERS}{_JS_POS_RECORD}" '
-                 f'onpause="{_JS_POS_RECORD}" '
+                 f'onpause="{_JS_POS_RECORD_PAUSE}" '
                  f'ontimeupdate="{_JS_PLAYHEAD}{_JS_POS_RECORD}"')
     if hotswap and not small:
         attrs += f' data-hs="1" onloadedmetadata="{_JS_HOTSWAP}"'
+        on_canplay.append(_JS_HOTSWAP)   # fallback if loadedmetadata already passed
     if autodl:
         js_name = entry["name"].replace("\\", "").replace("'", "\\'")
-        attrs += (' oncanplay="if(!this.dataset.dld){this.dataset.dld=1;'
-                  "var l=document.createElement('a');l.href=this.src;"
-                  f"l.download='{js_name}';l.click();}}\"")
+        on_canplay.append("if(!this.dataset.dld){this.dataset.dld=1;"
+                          "var l=document.createElement('a');l.href=this.src;"
+                          f"l.download='{js_name}';l.click();}}")
+    if on_canplay:
+        attrs += f' oncanplay="{"".join(on_canplay)}"'
     if loop:
         attrs += " loop"
     elif radio:

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -447,11 +447,18 @@ def render_history(hist):
             f'padding-right:6px">{boot}{items}</div>')
 
 
-def render_queued(entry):
-    if entry is None:
+def render_queue_status(entry=None, generating=False):
+    """Subdued status chip for the Infinite Radio queue — no audio/spectrogram,
+    just Generating…/Ready (the swap uses the entry held in server state)."""
+    if generating:
+        body = "generating…"
+    elif entry is not None:
+        p = html_lib.escape(entry["prompt"]) or "<i>(no prompt)</i>"
+        body = f"ready — {p} · seed {entry['seed']}"
+    else:
         return ""
-    return ('<div style="font-weight:600; margin-top:14px">Queued next ▶</div>'
-            + render_player(entry, small=True))
+    return (f'<div style="margin-top:14px; color:#888; font-size:0.85em; opacity:0.7">'
+            f'<b>Queued next</b> · {body}</div>')
 
 
 # ── Gradio UI ──────────────────────────────────────────────────────────────
@@ -593,7 +600,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         }
         return entry, None
 
-    def _present(state, entry, opts, *, force_autoplay=False):
+    def _present(state, entry, opts, queued_panel, *, force_autoplay=False):
         """Make `entry` the current clip (previous current moves to history top)
         and render all output panels."""
         if state["current"] is not None:
@@ -605,7 +612,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                              radio="Infinite Radio" in opts)
         return (main, entry["timing"], "",
                 render_history(state["history"]),
-                render_queued(state["queued"]), state)
+                queued_panel, state)
 
     def generate(dit_name, decoder_name, prompt, negative_prompt,
                  seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
@@ -622,7 +629,9 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         # a manual Generate makes any queued clip stale (settings may have changed);
         # the chained pregen refills it when Infinite Radio is on
         state["queued"] = None
-        return _present(state, entry, output_opts or [])
+        opts = output_opts or []
+        queued_panel = render_queue_status(generating=True) if "Infinite Radio" in opts else ""
+        return _present(state, entry, opts, queued_panel)
 
     def promote(dit_name, decoder_name, prompt, negative_prompt,
                 seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
@@ -637,7 +646,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                             init_noise, a2a_audio, inpaint_audio, inp_start,
                             inp_end, output_opts, file_format, state)
         state["queued"] = None
-        return _present(state, q, output_opts or [], force_autoplay=True)
+        return _present(state, q, output_opts or [],
+                        render_queue_status(generating=True), force_autoplay=True)
 
     def pregen(dit_name, decoder_name, prompt, negative_prompt,
                seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
@@ -656,9 +666,11 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             return (f"<div style='color:#f88; font-size:0.85em'>queue: {err_msg}</div>",
                     state)
         state["queued"] = entry
-        return render_queued(entry), state
+        return render_queue_status(entry), state
 
-    with gr.Blocks(title="SA3 MLX") as demo:
+    # sa3-promote must stay MOUNTED for the onended click to find it —
+    # visible=False would remove it from the DOM entirely, so hide via CSS.
+    with gr.Blocks(title="SA3 MLX", css="#sa3-promote{display:none !important}") as demo:
         gr.Markdown(
             "# SA3 MLX — Apple Silicon\n"
             "All modes wired: text-to-audio, CFG + negative prompt, audio-to-audio "
@@ -688,7 +700,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                                   max_lines=1, value="")
                 generate_btn = gr.Button("Generate", variant="primary", size="lg",
                                          elem_id="sa3-generate")
-                promote_btn = gr.Button("", visible=False, elem_id="sa3-promote")
+                promote_btn = gr.Button("", elem_id="sa3-promote")   # CSS-hidden, DOM-present
 
                 with gr.Accordion("Advanced", open=False):
                     with gr.Row():

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -64,6 +64,29 @@ DEFAULT_DECODERS = {name: cfg["default_decoder"] for name, cfg in DIT_CHOICES.it
 _GEN_LOCK = threading.Lock()
 
 
+def read_audio_any(path: str) -> np.ndarray:
+    """(2, T) float32 @ 44.1 kHz from any common upload format.
+
+    Layered: read_wav handles 16-bit/44.1k natively and shells out to ffmpeg
+    for the rest when installed; if that fails (no ffmpeg), soundfile's bundled
+    libsndfile decodes mp3/flac/ogg/24-bit/48 kHz directly, followed by a
+    linear resample to 44.1 kHz."""
+    try:
+        return read_wav(path)
+    except Exception:
+        import soundfile as sf
+        data, sr = sf.read(path, dtype="float32", always_2d=True)   # (T, ch)
+        y = data.T
+        y = np.stack([y[0], y[0]]) if y.shape[0] == 1 else y[:2]
+        if sr != SAMPLE_RATE:
+            in_len = y.shape[-1]
+            new_len = int(round(in_len * SAMPLE_RATE / sr))
+            scale = in_len / new_len
+            pos = np.clip((np.arange(new_len) + 0.5) * scale - 0.5, 0, in_len - 1)
+            y = np.stack([np.interp(pos, np.arange(in_len), ch) for ch in y])
+        return np.ascontiguousarray(y, dtype=np.float32)
+
+
 def _prune_old_outputs():
     wavs = sorted(OUTPUT_DIR.glob("*.wav"), key=lambda p: p.stat().st_mtime, reverse=True)
     for old in wavs[KEEP_RECENT_N:]:
@@ -197,7 +220,7 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
         if (T_lat * 16) % pad_mod != 0:
             enc_T_lat = math.ceil((T_lat * 16) / pad_mod) * pad_mod // 16
         target_samples = enc_T_lat * SAMPLES_PER_LATENT
-        audio_np = read_wav(path)
+        audio_np = read_audio_any(path)
         if audio_np.shape[-1] >= target_samples:
             audio_np = audio_np[:, :target_samples]
         else:

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -376,9 +376,12 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         except ValueError:
             seed = _random.randint(0, 2**31 - 1)
             notes.append(f"seed wasn't an integer — used random seed {seed}")
-        sigma_max = float(sigma_max)
+        # init_noise_level only means something with guide audio — pure prompt
+        # generations always run the full schedule (σmax = 1.0).
+        sigma_max = float(sigma_max) if a2a_audio else 1.0
         if sigma_max < MIN_SIGMA:
-            notes.append(f"σmax clamped to {MIN_SIGMA} (model is undefined at t≈0)")
+            notes.append(f"init_noise_level 0 runs at {MIN_SIGMA} (model is undefined at t≈0) — "
+                         "output ≈ the re-encoded input")
             sigma_max = MIN_SIGMA
 
         inpaint_range = None
@@ -486,8 +489,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                     a2a_audio = gr.Audio(label="Guide audio — generation starts from its latents",
                                          type="filepath")
                     sigma_slider = gr.Slider(
-                        label="σmax — how strongly to re-noise the guide (0.4–0.8 typical; 1.0 = ignore)",
-                        minimum=0.05, maximum=1.2, value=1.0, step=0.05)
+                        label="init_noise_level (1.0 = prompt, ~0.92 = fusion, 0 = input)",
+                        minimum=0.0, maximum=1.0, value=0.92, step=0.01)
 
                 with gr.Accordion("Inpainting (regenerate a span of reference audio)", open=False):
                     inpaint_audio = gr.Audio(label="Reference audio — kept bit-exact outside the range",

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -389,6 +389,15 @@ _JS_PAUSE_OTHERS = ("var t=this;document.querySelectorAll('audio').forEach("
                     "function(o){if(o!==t)o.pause();});")
 _JS_PLAYHEAD = ("var p=this.closest('.blk').querySelector('.ph');"
                 "if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+'%';")
+# Main-player position ledger (for Hotswap): every timeupdate/play/pause stamps
+# the current position so a freshly swapped-in element can resume exactly there.
+_JS_POS_RECORD = "window._sa3Pos={t:this.currentTime,playing:!this.paused,ts:Date.now()};"
+# Hotswap resume: if the previous main audio was playing when this one arrived,
+# jump to its position (+ the split-second since the last stamp) and keep going;
+# beyond the new clip's duration -> start at zero.
+_JS_HOTSWAP = ("if(this.dataset.hs==='1'){var s=window._sa3Pos;"
+               "if(s&&s.playing){var tt=s.t+(Date.now()-s.ts)/1000;"
+               "this.currentTime=(this.duration&&tt<this.duration)?tt:0;this.play();}}")
 _JS_SEEK = ("var a=this.closest('.blk').querySelector('audio');"
             "var r=this.getBoundingClientRect();"
             "if(a&&a.duration){a.currentTime=(event.clientX-r.left)/r.width*a.duration;a.play();}")
@@ -446,18 +455,29 @@ def _meta_suffix(entry) -> str:
 
 
 def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=False,
-                  bg=None, advance=False):
+                  bg=None, advance=False, loop=False, hotswap=False):
     """One self-contained player block: audio + caption + seekable spectrogram
     with playhead. Global one-at-a-time playback via onplay pause-others.
     small: audio + spectrogram side by side (half width each), 'Xm ago' caption.
-    advance: on ended, hop to the next history item's audio (Auto-play)."""
-    attrs = f'onplay="{_JS_PAUSE_OTHERS}" ontimeupdate="{_JS_PLAYHEAD}"'
+    advance: on ended, hop to the next history item's audio (Auto-play).
+    loop: native loop attribute — finished audio restarts (suppresses ended).
+    hotswap: main slot only — resume at the previous clip's position on arrival."""
+    if small:
+        attrs = f'onplay="{_JS_PAUSE_OTHERS}" ontimeupdate="{_JS_PLAYHEAD}"'
+    else:
+        attrs = (f'onplay="{_JS_PAUSE_OTHERS}{_JS_POS_RECORD}" '
+                 f'onpause="{_JS_POS_RECORD}" '
+                 f'ontimeupdate="{_JS_PLAYHEAD}{_JS_POS_RECORD}"')
+    if hotswap and not small:
+        attrs += f' data-hs="1" onloadedmetadata="{_JS_HOTSWAP}"'
     if autodl:
         js_name = entry["name"].replace("\\", "").replace("'", "\\'")
         attrs += (' oncanplay="if(!this.dataset.dld){this.dataset.dld=1;'
                   "var l=document.createElement('a');l.href=this.src;"
                   f"l.download='{js_name}';l.click();}}\"")
-    if radio:
+    if loop:
+        attrs += " loop"
+    elif radio:
         attrs += f' onended="{_JS_PROMOTE}"'
     elif advance:
         attrs += (' onended="var b=this.closest(\'.blk\');'
@@ -504,12 +524,12 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
             f'{audio_el}{cap}{spec}</div>')
 
 
-def render_history(hist, advance=False):
+def render_history(hist, advance=False, loop=False):
     if not hist:
         return ""
     # zebra striping instead of separators: light grey vs medium grey rows
     items = "".join(
-        render_player(e, small=True, advance=advance,
+        render_player(e, small=True, advance=advance, loop=loop,
                       bg="rgba(127,127,127,0.24)" if i % 2 else "rgba(127,127,127,0.08)")
         for i, e in enumerate(hist))
     boot = f'<img src="data:," style="display:none" onerror="{_JS_SCROLL_RESTORE}"/>'
@@ -685,12 +705,15 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         if state["current"] is not None:
             state["history"].insert(0, state["current"])
         state["current"] = entry
+        loop = "Loop" in opts
         main = render_player(entry,
                              autoplay=force_autoplay or "Auto-play" in opts,
                              autodl="Auto-download" in opts,
-                             radio="Infinite Radio" in opts)
+                             radio="Infinite Radio" in opts and not loop,
+                             loop=loop,
+                             hotswap="Hotswap" in opts)
         return (main, entry["timing"], "",
-                render_history(state["history"], advance="Auto-play" in opts),
+                render_history(state["history"], advance="Auto-play" in opts, loop=loop),
                 queued_panel, state)
 
     def generate(dit_name, decoder_name, prompt, negative_prompt,
@@ -812,8 +835,9 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
 
                 with gr.Accordion("Output", open=False):
                     output_opts = gr.CheckboxGroup(
-                        ["Auto-play", "Auto-download", "Infinite Radio"],
+                        ["Auto-play", "Auto-download", "Infinite Radio", "Loop", "Hotswap"],
                         value=["Auto-play"], label="Options")
+                    opts_state = gr.State(["Auto-play"])
                     file_format = gr.Radio(
                         [FORMAT_MP3, FORMAT_WAV] if FFMPEG else [FORMAT_WAV],
                         value=FORMAT_MP3 if FFMPEG else FORMAT_WAV,
@@ -833,6 +857,19 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         def on_seconds_change(sec):
             return gr.update(maximum=sec), gr.update(maximum=sec)
         seconds.change(on_seconds_change, inputs=[seconds], outputs=[inp_start, inp_end])
+
+        def on_opts_change(opts, prev):
+            """Loop and Infinite Radio are mutually exclusive — the one just
+            ticked wins, the other unticks."""
+            opts = opts or []
+            if "Loop" in opts and "Infinite Radio" in opts:
+                added = set(opts) - set(prev or [])
+                drop = "Infinite Radio" if "Loop" in added else "Loop"
+                opts = [o for o in opts if o != drop]
+                return gr.update(value=opts), opts
+            return gr.update(), opts
+        output_opts.change(on_opts_change, inputs=[output_opts, opts_state],
+                           outputs=[output_opts, opts_state])
 
         ctrl_inputs = [dit_dd, decoder_dd, prompt, negative_prompt,
                        seconds, steps, seed, cfg, apg, sigma_global,

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -727,7 +727,12 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
 
     # sa3-promote must stay MOUNTED for the onended click to find it —
     # visible=False would remove it from the DOM entirely, so hide via CSS.
-    with gr.Blocks(title="SA3 MLX", css="#sa3-promote{display:none !important}") as demo:
+    # sa3-out: collapse the column's flex gap + wrapper padding so the
+    # spectrogram caption / timing line / queued status sit tightly together.
+    _css = ("#sa3-promote{display:none !important}"
+            "#sa3-out{gap:4px !important}"
+            "#sa3-out .html-container{padding:0 !important; margin:0 !important}")
+    with gr.Blocks(title="SA3 MLX", css=_css) as demo:
         gr.Markdown(
             "# SA3 MLX — Apple Silicon\n"
             "Text-to-audio, CFG + negative prompt, audio-to-audio, inpainting. "
@@ -792,7 +797,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                         value=FORMAT_MP3 if FFMPEG else FORMAT_WAV,
                         label="Format", visible=FFMPEG)
 
-            with gr.Column(scale=2):
+            with gr.Column(scale=2, elem_id="sa3-out"):
                 gr.Markdown("**Output**")
                 output_player = gr.HTML()
                 timing = gr.HTML()

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -392,12 +392,15 @@ _JS_PLAYHEAD = ("var p=this.closest('.blk').querySelector('.ph');"
                 "if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+'%';")
 # Main-player position ledger (for Hotswap): every timeupdate/play/pause stamps
 # the current position so a freshly swapped-in element can resume exactly there.
-# EVERY recorder is guarded on isConnected: when the old element is removed
-# during the swap, the browser fires a teardown pause AND a final timeupdate on
-# the detached element — either would overwrite the playing:true stamp and kill
-# the resume. Detached elements never get to write the ledger.
-_JS_POS_RECORD = ("if(this.isConnected){window._sa3Pos="
-                  "{t:this.currentTime,playing:!this.paused,ts:Date.now()};}")
+# Guards (all verified via CDP against the live page):
+#  - isConnected: teardown fires a pause AND a final timeupdate on the removed
+#    element — detached elements never write the ledger.
+#  - unresumed hotswap candidates (data-hs set, hsd not yet) don't write either:
+#    with autoplay, the NEW element's 'play' event fires BEFORE loadedmetadata
+#    and would stamp t≈0 over the old clip's position right before the resume
+#    handler reads it.
+_JS_POS_RECORD = ("if(this.isConnected&&!(this.dataset.hs==='1'&&!this.dataset.hsd))"
+                  "{window._sa3Pos={t:this.currentTime,playing:!this.paused,ts:Date.now()};}")
 # Hotswap resume: if the previous main audio was playing when this one arrived,
 # jump to its position (+ the split-second since the last stamp) and keep going;
 # beyond the new clip's duration -> start at zero. Guarded (hsd) so it applies
@@ -513,7 +516,10 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
     spec_core = ""
     if entry.get("spec_b64"):
         height = "height:56px;" if small else ""
-        spec_core = (f'<div style="position:relative; cursor:pointer" onclick="{_JS_SEEK}">'
+        tip = ("3-band tinted stereo mel · red=bass / green=mid / blue=high · "
+               "L top, R bottom · click to seek")
+        spec_core = (f'<div style="position:relative; cursor:pointer" title="{tip}" '
+                     f'onclick="{_JS_SEEK}">'
                      f'<img src="data:image/png;base64,{entry["spec_b64"]}" '
                      f'style="width:100%; {height} display:block; image-rendering:pixelated; '
                      f'border:1px solid #333" alt="spectrogram"/>'
@@ -533,13 +539,8 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
         return (f'<div class="blk" data-key="{entry["key"]}" style="{style}">'
                 f'{row}{cap}</div>')
 
-    spec = spec_core
-    if spec_core:
-        spec += ('<div style="font-size:0.75em; color:#666; margin-top:2px">'
-                 '3-band tinted stereo mel · red=bass / green=mid / blue=high · '
-                 'L top, R bottom · click to seek</div>')
     return (f'<div class="blk" data-key="{entry["key"]}">'
-            f'{audio_el}{spec}</div>')
+            f'{audio_el}{spec_core}</div>')
 
 
 def render_history(hist, advance=False, loop=False):
@@ -824,9 +825,6 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                                       value=default_steps, step=1)
                     cfg = gr.Slider(label="CFG", minimum=0.0, maximum=10.0,
                                     value=1.0, step=0.1)
-                generate_btn = gr.Button("Generate", variant="primary", size="lg",
-                                         elem_id="sa3-generate")
-                promote_btn = gr.Button("", elem_id="sa3-promote")   # CSS-hidden, DOM-present
 
                 with gr.Accordion("Advanced", open=False):
                     with gr.Row():
@@ -863,6 +861,9 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                         label="Format", visible=FFMPEG)
 
             with gr.Column(scale=2, elem_id="sa3-out"):
+                generate_btn = gr.Button("Generate", variant="primary", size="lg",
+                                         elem_id="sa3-generate")
+                promote_btn = gr.Button("", elem_id="sa3-promote")   # CSS-hidden, DOM-present
                 gr.Markdown("**Output**")
                 output_player = gr.HTML()
                 timing = gr.HTML()

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -232,7 +232,11 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
         cond_d = x.astype(mx.float32) - cond_v.astype(mx.float32) * sigma
         uncond_d = x.astype(mx.float32) - uncond_v.astype(mx.float32) * sigma
         diff = cond_d - uncond_d
-        if apg <= 0.0:
+        # cfg < 1 is the INTERPOLATION regime: cfg_d = lerp(uncond_d, cond_d, cfg),
+        # so 0 = pure negative/uncond branch, 0.5 = halfway between both prompts.
+        # APG's orthogonal projection would bend that line — it only applies to the
+        # extrapolation regime (cfg > 1) it was designed for.
+        if apg <= 0.0 or cfg < 1.0:
             cfg_diff = diff
         else:
             norm = mx.sqrt((cond_d * cond_d).sum(axis=(-2, -1), keepdims=True))
@@ -400,11 +404,15 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 generate_btn = gr.Button("Generate", variant="primary", size="lg")
 
                 with gr.Accordion("CFG / negative prompt", open=False):
-                    cfg = gr.Slider(label="CFG scale (1.0 = off)", minimum=1.0,
-                                    maximum=10.0, value=1.0, step=0.1)
-                    apg = gr.Slider(label="APG (1 = full orthogonal projection, 0 = vanilla CFG)",
+                    cfg = gr.Slider(label="CFG scale — 1 = prompt only (off) · 0 = negative prompt "
+                                          "only · 0.5 = halfway between both · >1 = push beyond prompt",
+                                    minimum=0.0, maximum=10.0, value=1.0, step=0.1)
+                    apg = gr.Slider(label="APG (1 = full orthogonal projection, 0 = vanilla CFG; "
+                                          "applies only when CFG > 1)",
                                     minimum=0.0, maximum=1.0, value=1.0, step=0.05)
-                    negative_prompt = gr.Textbox(label="Negative prompt (needs CFG > 1)", lines=1)
+                    negative_prompt = gr.Textbox(
+                        label="Negative prompt (active when CFG ≠ 1; at CFG 0 it fully takes over — "
+                              "blank = unconditional)", lines=1)
 
                 with gr.Accordion("Audio-to-audio / inpainting", open=False):
                     init_audio = gr.Audio(label="Init audio (enables a2a; add a range below for inpainting)",

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -364,7 +364,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         return gr.update(value=DEFAULT_DECODERS.get(dit_name, "same-s"))
 
     def generate(dit_name, decoder_name, prompt, negative_prompt,
-                 seconds, steps, seed_text, cfg, apg, sigma_max,
+                 seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
                  a2a_audio, inpaint_audio, inp_start, inp_end):
         err = lambda m: ("", "", "", f"<span style='color:#f88'>{m}</span>")
         prompt = (prompt or "").strip()
@@ -376,12 +376,13 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         except ValueError:
             seed = _random.randint(0, 2**31 - 1)
             notes.append(f"seed wasn't an integer — used random seed {seed}")
-        # init_noise_level only means something with guide audio — pure prompt
-        # generations always run the full schedule (σmax = 1.0).
-        sigma_max = float(sigma_max) if a2a_audio else 1.0
+        # sigma_max governs every generation's schedule start; when guide audio is
+        # present (a2a), init_noise_level overrides it (parent-repo gradio semantics).
+        sigma_max = float(init_noise) if a2a_audio else float(sigma_max)
         if sigma_max < MIN_SIGMA:
-            notes.append(f"init_noise_level 0 runs at {MIN_SIGMA} (model is undefined at t≈0) — "
-                         "output ≈ the re-encoded input")
+            which = "init_noise_level" if a2a_audio else "sigma_max"
+            notes.append(f"{which} 0 runs at {MIN_SIGMA} (model is undefined at t≈0)"
+                         + (" — output ≈ the re-encoded input" if a2a_audio else ""))
             sigma_max = MIN_SIGMA
 
         inpaint_range = None
@@ -481,8 +482,11 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 generate_btn = gr.Button("Generate", variant="primary", size="lg")
 
                 with gr.Accordion("Advanced", open=False):
-                    apg = gr.Slider(label="APG (only applies when CFG > 1)",
-                                    minimum=0.0, maximum=1.0, value=1.0, step=0.05)
+                    with gr.Row():
+                        apg = gr.Slider(label="APG (only applies when CFG > 1)",
+                                        minimum=0.0, maximum=1.0, value=1.0, step=0.05)
+                        sigma_global = gr.Slider(label="sigma_max",
+                                                 minimum=0.0, maximum=1.0, value=1.0, step=0.01)
                     negative_prompt = gr.Textbox(label="Negative prompt", lines=1)
 
                 with gr.Accordion("Audio-to-audio (guide the whole clip)", open=False):
@@ -521,8 +525,9 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
 
         generate_btn.click(generate,
                            inputs=[dit_dd, decoder_dd, prompt, negative_prompt,
-                                   seconds, steps, seed, cfg, apg, sigma_slider,
-                                   a2a_audio, inpaint_audio, inp_start, inp_end],
+                                   seconds, steps, seed, cfg, apg, sigma_global,
+                                   sigma_slider, a2a_audio, inpaint_audio,
+                                   inp_start, inp_end],
                            outputs=[output_audio, output_spec, timing, error_box])
 
         gr.Markdown(

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -4,10 +4,12 @@ The MLX sibling of optimized/tensorRT/scripts/sa3_gradio.py, with every
 generation mode wired (the TRT one only exposes text-to-audio):
   - Model picker: sm-music / sm-sfx / medium (hot-swap; models cache in unified
     memory, LRU-evicted — first switch loads weights, subsequent instant)
-  - CFG + negative prompt (batched CFG with APG, same math as sa3_mlx.py)
-  - Audio-to-audio: upload init audio + σmax slider
-  - Inpainting: init audio + "START,END" seconds range (paste-back guaranteed
-    bit-exact outside the range)
+  - CFG 0-10 next to seconds/steps (0 = negative prompt takes over, 0.5 = halfway
+    between prompts, 1 = off, >1 = extrapolate) + negative prompt/APG under Advanced
+  - Audio-to-audio: guide audio + σmax slider (whole clip starts from its latents)
+  - Inpainting: separate reference audio + start/end range sliders (kept bit-exact
+    outside the range). Combinable with a2a: the regenerated span then starts
+    from the guide audio instead of noise.
   - Spectrogram display: 3-band tinted stereo mel spectrogram (numpy port —
     no torch), rendered inline alongside the audio
 
@@ -21,6 +23,7 @@ import argparse
 import base64
 import math
 import sys
+import threading
 import time
 import uuid
 import wave
@@ -53,6 +56,12 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 KEEP_RECENT_N = 20
 MIN_SIGMA = 0.01
 DEFAULT_DECODERS = {name: cfg["default_decoder"] for name, cfg in DIT_CHOICES.items()}
+
+# gradio runs handlers on anyio worker threads; MLX keeps its default stream
+# per-thread, so a handler can land on a thread with no GPU stream registered
+# ("There is no Stream(gpu, 0) in current thread"). One generation at a time,
+# and every generation re-pins the default device on its thread.
+_GEN_LOCK = threading.Lock()
 
 
 def _prune_old_outputs():
@@ -135,9 +144,20 @@ def get_encoder(decoder_name: str):
 def run_generation(dit_name: str, decoder_name: str, prompt: str,
                    negative_prompt: str, seconds: float, steps: int,
                    seed: int, cfg: float, apg: float, sigma_max: float,
-                   init_audio_path: str | None, inpaint_range_sec):
-    """Returns (audio_np (2,T) float32, timings dict)."""
+                   a2a_audio_path: str | None = None,
+                   inpaint_audio_path: str | None = None,
+                   inpaint_range_sec=None):
+    """Returns (audio_np (2,T) float32, timings dict).
+
+    a2a and inpainting are independent and combinable:
+      - a2a_audio_path: the whole generation STARTS from this audio's latents
+        (noise = lat*(1-σmax) + noise*σmax)
+      - inpaint_audio_path + inpaint_range_sec: kept bit-exact outside the range
+        (local_add_cond context + per-step paste-back)
+      - both: the inpainted span regenerates FROM the a2a guide instead of pure noise
+    """
     t = {}
+    mx.set_default_device(mx.gpu)   # thread-local in MLX — see _GEN_LOCK note
     dtype = mx.float16   # MLX canonical DiT dtype
     T_lat = max(1, math.ceil(seconds * SAMPLE_RATE / SAMPLES_PER_LATENT))
 
@@ -170,25 +190,34 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
     mx.eval(cross_attn, global_cond)
     t["cond_ms"] = (time.time() - t0) * 1000
 
-    # 3a. (a2a / inpaint) encode init audio → latents
-    init_latents = None
-    if init_audio_path:
-        t0 = time.time()
+    # 3a. encode the provided audio inputs → latents (each is optional)
+    def encode_audio(path):
         enc_model, pad_mod = get_encoder(decoder_name)
         enc_T_lat = T_lat
         if (T_lat * 16) % pad_mod != 0:
             enc_T_lat = math.ceil((T_lat * 16) / pad_mod) * pad_mod // 16
         target_samples = enc_T_lat * SAMPLES_PER_LATENT
-        audio_np = read_wav(init_audio_path)
+        audio_np = read_wav(path)
         if audio_np.shape[-1] >= target_samples:
             audio_np = audio_np[:, :target_samples]
         else:
             audio_np = np.pad(audio_np, ((0, 0), (0, target_samples - audio_np.shape[-1])))
         patches_np = patch_audio(audio_np[None, ...], patch_size=256)
-        init_latents = enc_model(mx.array(patches_np))[..., :T_lat]
-        mx.eval(init_latents)
-        init_latents = init_latents.astype(dtype)
-        t["enc_ms"] = (time.time() - t0) * 1000
+        lat = enc_model(mx.array(patches_np))[..., :T_lat]
+        mx.eval(lat)
+        return lat.astype(dtype)
+
+    a2a_latents = None      # start-point guide (whole clip)
+    ctx_latents = None      # inpaint context (kept outside the range)
+    t["enc_ms"] = 0.0
+    if a2a_audio_path:
+        t0 = time.time()
+        a2a_latents = encode_audio(a2a_audio_path)
+        t["enc_ms"] += (time.time() - t0) * 1000
+    if inpaint_audio_path and inpaint_range_sec is not None:
+        t0 = time.time()
+        ctx_latents = encode_audio(inpaint_audio_path)
+        t["enc_ms"] += (time.time() - t0) * 1000
 
     # 3b. DiT + pingpong sample
     dit_model, t["dit_load_ms"] = get_dit(dit_name, T_lat, dtype)
@@ -196,27 +225,26 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
 
     key = mx.random.key(seed)
     pure_noise = mx.random.normal((1, 256, T_lat), dtype=dtype, key=key)
-    inpaint_lat = None
-    if inpaint_range_sec is not None:
-        s0 = max(0, int(round(inpaint_range_sec[0] * SAMPLE_RATE / SAMPLES_PER_LATENT)))
-        s1 = min(T_lat, int(round(inpaint_range_sec[1] * SAMPLE_RATE / SAMPLES_PER_LATENT)))
-        inpaint_lat = (s0, s1)
-    if init_latents is not None and inpaint_lat is None:
-        noise = init_latents * (1.0 - sigma_max) + pure_noise * sigma_max
+    # a2a start-point mix is independent of inpainting: when both are set, the
+    # inpainted span regenerates FROM the guide audio instead of pure noise
+    # (the kept span is pasted back from ctx_latents every step regardless).
+    if a2a_latents is not None:
+        noise = a2a_latents * (1.0 - sigma_max) + pure_noise * sigma_max
     else:
         noise = pure_noise
     mx.eval(noise)
 
     local_add_cond = None
     paste_back = None
-    if inpaint_lat is not None:
-        s0, s1 = inpaint_lat
+    if ctx_latents is not None:
+        s0 = max(0, int(round(inpaint_range_sec[0] * SAMPLE_RATE / SAMPLES_PER_LATENT)))
+        s1 = min(T_lat, int(round(inpaint_range_sec[1] * SAMPLE_RATE / SAMPLES_PER_LATENT)))
         mask_np = np.ones((1, 1, T_lat), dtype=np.float32)
         mask_np[:, :, s0:s1] = 0.0
         keep = mx.array(mask_np)
-        masked_input = init_latents.astype(mx.float32) * keep
+        masked_input = ctx_latents.astype(mx.float32) * keep
         local_add_cond = mx.concatenate([keep, masked_input], axis=1).transpose(0, 2, 1).astype(dtype)
-        paste_back = (init_latents, keep)
+        paste_back = (ctx_latents, keep)
 
     def model_fn(x, tt):
         if cfg == 1.0:
@@ -304,7 +332,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
 
     def generate(dit_name, decoder_name, prompt, negative_prompt,
                  seconds, steps, seed_text, cfg, apg, sigma_max,
-                 init_audio, inpaint_text):
+                 a2a_audio, inpaint_audio, inp_start, inp_end):
         err = lambda m: ("", "", "", f"<span style='color:#f88'>{m}</span>")
         prompt = (prompt or "").strip()
         try:
@@ -314,24 +342,25 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         if sigma_max < MIN_SIGMA:
             return err(f"error: σmax must be ≥ {MIN_SIGMA} (rf_denoiser is undefined at t≈0)")
         inpaint_range = None
-        if inpaint_text and inpaint_text.strip():
-            if not init_audio:
-                return err("error: inpaint range requires init audio")
-            try:
-                s_str, e_str = inpaint_text.split(",")
-                inpaint_range = (float(s_str), float(e_str))
-            except ValueError:
-                return err(f"error: inpaint range must be 'START,END' seconds, got {inpaint_text!r}")
-            if not (0 <= inpaint_range[0] < inpaint_range[1] <= seconds):
-                return err(f"error: need 0 ≤ start < end ≤ {seconds}s")
+        if inpaint_audio:
+            if inp_end <= inp_start:
+                return err("error: set the inpaint range sliders (end must be > start)")
+            if inp_end > seconds:
+                return err(f"error: inpaint end {inp_end}s exceeds clip length {seconds}s")
+            inpaint_range = (float(inp_start), float(inp_end))
+        elif inp_end > inp_start:
+            return err("error: inpaint range set but no reference audio uploaded")
 
-        mode = ("inpaint" if inpaint_range else
-                "audio-to-audio" if init_audio else "text-to-audio")
+        mode = ("a2a+inpaint" if (a2a_audio and inpaint_range) else
+                "inpaint" if inpaint_range else
+                "audio-to-audio" if a2a_audio else "text-to-audio")
         try:
-            audio_np, t = run_generation(
-                dit_name, decoder_name, prompt, negative_prompt or "",
-                float(seconds), int(steps), seed, float(cfg), float(apg),
-                float(sigma_max), init_audio or None, inpaint_range)
+            with _GEN_LOCK:
+                audio_np, t = run_generation(
+                    dit_name, decoder_name, prompt, negative_prompt or "",
+                    float(seconds), int(steps), seed, float(cfg), float(apg),
+                    float(sigma_max), a2a_audio or None, inpaint_audio or None,
+                    inpaint_range)
         except Exception as e:
             return err(f"error: {type(e).__name__}: {e}")
         if not np.isfinite(audio_np).all():
@@ -399,33 +428,36 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                                         value=default_seconds, step=1)
                     steps = gr.Slider(label="Steps", minimum=1, maximum=16,
                                       value=default_steps, step=1)
+                    cfg = gr.Slider(label="CFG", minimum=0.0, maximum=10.0,
+                                    value=1.0, step=0.1)
                 seed = gr.Textbox(label="Seed (optional, blank = random)",
                                   max_lines=1, value="")
                 generate_btn = gr.Button("Generate", variant="primary", size="lg")
 
-                with gr.Accordion("CFG / negative prompt", open=False):
-                    cfg = gr.Slider(label="CFG scale — 1 = prompt only (off) · 0 = negative prompt "
-                                          "only · 0.5 = halfway between both · >1 = push beyond prompt",
-                                    minimum=0.0, maximum=10.0, value=1.0, step=0.1)
-                    apg = gr.Slider(label="APG (1 = full orthogonal projection, 0 = vanilla CFG; "
-                                          "applies only when CFG > 1)",
+                with gr.Accordion("Advanced", open=False):
+                    apg = gr.Slider(label="APG (only applies when CFG > 1)",
                                     minimum=0.0, maximum=1.0, value=1.0, step=0.05)
-                    negative_prompt = gr.Textbox(
-                        label="Negative prompt (active when CFG ≠ 1; at CFG 0 it fully takes over — "
-                              "blank = unconditional)", lines=1)
+                    negative_prompt = gr.Textbox(label="Negative prompt", lines=1)
 
-                with gr.Accordion("Audio-to-audio / inpainting", open=False):
-                    init_audio = gr.Audio(label="Init audio (enables a2a; add a range below for inpainting)",
-                                          type="filepath")
-                    sigma_slider = gr.Slider(label="Init noise level σmax (a2a: 0.4–0.8 typical; 1.0 = ignore init)",
-                                             minimum=0.05, maximum=1.2, value=1.0, step=0.05)
-                    inpaint_text = gr.Textbox(
-                        label="Inpaint range 'START,END' seconds (regenerates just that span; blank = a2a)",
-                        max_lines=1, value="")
+                with gr.Accordion("Audio-to-audio (guide the whole clip)", open=False):
+                    a2a_audio = gr.Audio(label="Guide audio — generation starts from its latents",
+                                         type="filepath")
+                    sigma_slider = gr.Slider(
+                        label="σmax — how strongly to re-noise the guide (0.4–0.8 typical; 1.0 = ignore)",
+                        minimum=0.05, maximum=1.2, value=1.0, step=0.05)
+
+                with gr.Accordion("Inpainting (regenerate a span of reference audio)", open=False):
+                    inpaint_audio = gr.Audio(label="Reference audio — kept bit-exact outside the range",
+                                             type="filepath")
+                    with gr.Row():
+                        inp_start = gr.Slider(label="Start (s)", minimum=0, maximum=120,
+                                              value=0, step=0.5)
+                        inp_end = gr.Slider(label="End (s)", minimum=0, maximum=120,
+                                            value=0, step=0.5)
                     gr.Markdown(
-                        "<span style='color:#888; font-size:0.85em'>a2a wants clips ≥ ~20 s "
-                        "(shorter inputs give repetitive latents). Inpainting reads best with "
-                        "CFG ≥ 5 and a contrasting prompt.</span>")
+                        "<span style='color:#888; font-size:0.85em'>Reads best with CFG ≥ 5 and a "
+                        "contrasting prompt. Combinable with audio-to-audio: the regenerated span "
+                        "then starts from the guide audio instead of noise.</span>")
 
             with gr.Column(scale=2):
                 gr.Markdown("**Audio**")
@@ -436,10 +468,15 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 error_box = gr.HTML()
 
         dit_dd.change(on_dit_change, inputs=[dit_dd], outputs=[decoder_dd])
+
+        def on_seconds_change(sec):
+            return gr.update(maximum=sec), gr.update(maximum=sec)
+        seconds.change(on_seconds_change, inputs=[seconds], outputs=[inp_start, inp_end])
+
         generate_btn.click(generate,
                            inputs=[dit_dd, decoder_dd, prompt, negative_prompt,
                                    seconds, steps, seed, cfg, apg, sigma_slider,
-                                   init_audio, inpaint_text],
+                                   a2a_audio, inpaint_audio, inp_start, inp_end],
                            outputs=[output_audio, output_spec, timing, error_box])
 
         gr.Markdown(

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -411,10 +411,11 @@ def _ago(ts) -> str:
 
 
 def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=False,
-                  bg=None):
+                  bg=None, advance=False):
     """One self-contained player block: audio + caption + seekable spectrogram
     with playhead. Global one-at-a-time playback via onplay pause-others.
-    small: audio + spectrogram side by side (half width each), 'Xm ago' caption."""
+    small: audio + spectrogram side by side (half width each), 'Xm ago' caption.
+    advance: on ended, hop to the next history item's audio (Auto-play)."""
     attrs = f'onplay="{_JS_PAUSE_OTHERS}" ontimeupdate="{_JS_PLAYHEAD}"'
     if autodl:
         js_name = entry["name"].replace("\\", "").replace("'", "\\'")
@@ -423,6 +424,11 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
                   f"l.download='{js_name}';l.click();}}\"")
     if radio:
         attrs += f' onended="{_JS_PROMOTE}"'
+    elif advance:
+        attrs += (' onended="var b=this.closest(\'.blk\');'
+                  "var n=b?b.nextElementSibling:null;"
+                  "while(n&&!n.classList.contains('blk'))n=n.nextElementSibling;"
+                  "if(n){var a=n.querySelector('audio');if(a)a.play();}\"")
     auto = "autoplay " if autoplay else ""
     audio_el = (f'<audio controls {auto}style="width:100%" {attrs} '
                 f'src="data:{entry["mime"]};base64,{entry["b64"]}"></audio>')
@@ -445,8 +451,7 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
                f'<div style="flex:1; min-width:0">{audio_el}</div>'
                f'<div style="flex:1; min-width:0">{spec_core}</div></div>')
         cap = (f'<div style="font-size:0.8em; margin:2px 0; color:#888">'
-               f'{_ago(entry.get("ts"))} · {prompt_disp} · seed {entry["seed"]} · '
-               f'<code>{html_lib.escape(entry["name"])}</code></div>')
+               f'{_ago(entry.get("ts"))} · {prompt_disp} · seed {entry["seed"]}</div>')
         style = f"padding:6px 8px;{' background:' + bg + ';' if bg else ''}"
         return (f'<div class="blk" data-key="{entry["key"]}" style="{style}">'
                 f'{row}{cap}</div>')
@@ -463,12 +468,13 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
             f'{audio_el}{cap}{spec}</div>')
 
 
-def render_history(hist):
+def render_history(hist, advance=False):
     if not hist:
         return ""
-    # zebra striping instead of separators: light grey on every other row
+    # zebra striping instead of separators: light grey vs medium grey rows
     items = "".join(
-        render_player(e, small=True, bg="rgba(127,127,127,0.12)" if i % 2 else None)
+        render_player(e, small=True, advance=advance,
+                      bg="rgba(127,127,127,0.24)" if i % 2 else "rgba(127,127,127,0.08)")
         for i, e in enumerate(hist))
     boot = f'<img src="data:," style="display:none" onerror="{_JS_SCROLL_RESTORE}"/>'
     return (f'<div style="font-weight:600; margin-top:14px">Previous generations ({len(hist)})</div>'
@@ -487,7 +493,7 @@ def render_queue_status(entry=None, generating=False):
         body = f"ready — {p} · seed {entry['seed']}"
     else:
         return ""
-    return (f'<div style="margin-top:14px; color:#888; font-size:0.85em; opacity:0.7">'
+    return (f'<div style="margin-top:2px; color:#888; font-size:0.85em; opacity:0.7">'
             f'<b>Queued next</b> · {body}</div>')
 
 
@@ -642,7 +648,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                              autodl="Auto-download" in opts,
                              radio="Infinite Radio" in opts)
         return (main, entry["timing"], "",
-                render_history(state["history"]),
+                render_history(state["history"], advance="Auto-play" in opts),
                 queued_panel, state)
 
     def generate(dit_name, decoder_name, prompt, negative_prompt,

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -358,21 +358,28 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                  a2a_audio, inpaint_audio, inp_start, inp_end):
         err = lambda m: ("", "", "", f"<span style='color:#f88'>{m}</span>")
         prompt = (prompt or "").strip()
+        # Permissive by design: a generation should succeed with whatever IS set.
+        # Half-configured features are ignored with a visible note, never an error.
+        notes = []
         try:
             seed = int(seed_text.strip()) if seed_text and seed_text.strip() else _random.randint(0, 2**31 - 1)
         except ValueError:
-            return err("error: seed must be an integer")
+            seed = _random.randint(0, 2**31 - 1)
+            notes.append(f"seed wasn't an integer — used random seed {seed}")
+        sigma_max = float(sigma_max)
         if sigma_max < MIN_SIGMA:
-            return err(f"error: σmax must be ≥ {MIN_SIGMA} (rf_denoiser is undefined at t≈0)")
+            notes.append(f"σmax clamped to {MIN_SIGMA} (model is undefined at t≈0)")
+            sigma_max = MIN_SIGMA
+
         inpaint_range = None
-        if inpaint_audio:
-            if inp_end <= inp_start:
-                return err("error: set the inpaint range sliders (end must be > start)")
+        if inpaint_audio and inp_end > inp_start and inp_start < seconds:
             if inp_end > seconds:
-                return err(f"error: inpaint end {inp_end}s exceeds clip length {seconds}s")
-            inpaint_range = (float(inp_start), float(inp_end))
+                notes.append(f"inpaint end clamped to the clip length ({seconds:g}s)")
+            inpaint_range = (float(inp_start), float(min(inp_end, seconds)))
+        elif inpaint_audio:
+            notes.append("inpainting ignored — set the start/end range sliders")
         elif inp_end > inp_start:
-            return err("error: inpaint range set but no reference audio uploaded")
+            notes.append("inpaint range ignored — no reference audio uploaded")
 
         mode = ("a2a+inpaint" if (a2a_audio and inpaint_range) else
                 "inpaint" if inpaint_range else
@@ -427,6 +434,9 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             f"<b>seed</b>: <code>{seed}</code> ·&nbsp; "
             f"<b>T_lat</b>: {t['T_lat']} ·&nbsp; <b>samples</b>: {t['samples']}"
         )
+        if notes:
+            timing_html = ("".join(f"<div style='color:#fa3; font-size:0.85em'>note: {n}</div>"
+                                   for n in notes) + timing_html)
         return audio_html, spec_html, timing_html, ""
 
     with gr.Blocks(title="SA3 MLX") as demo:

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -55,6 +55,8 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 KEEP_RECENT_N = 20
 MIN_SIGMA = 0.01
 DEFAULT_DECODERS = {name: cfg["default_decoder"] for name, cfg in DIT_CHOICES.items()}
+# Trained max clip length per model (repo README model table).
+MAX_SECONDS = {"sm-music": 120, "sm-sfx": 120, "medium": 380}
 
 # MLX ≥0.31 registers GPU streams PER THREAD (ThreadLocalStream) while gradio
 # runs each handler on a rotating anyio worker thread — cross-thread MLX use
@@ -360,8 +362,10 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         get_dit(initial_dit, warm_T, mx.float16); get_decoder(initial_decoder)
     mlx_call(_warm)
 
-    def on_dit_change(dit_name):
-        return gr.update(value=DEFAULT_DECODERS.get(dit_name, "same-s"))
+    def on_dit_change(dit_name, cur_seconds):
+        max_s = MAX_SECONDS.get(dit_name, 120)
+        return (gr.update(value=DEFAULT_DECODERS.get(dit_name, "same-s")),
+                gr.update(maximum=max_s, value=min(cur_seconds, max_s)))
 
     def generate(dit_name, decoder_name, prompt, negative_prompt,
                  seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
@@ -376,6 +380,11 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         except ValueError:
             seed = _random.randint(0, 2**31 - 1)
             notes.append(f"seed wasn't an integer — used random seed {seed}")
+        # backstop for API callers bypassing the slider maxima
+        max_s = MAX_SECONDS.get(dit_name, 120)
+        if seconds > max_s:
+            notes.append(f"seconds clamped to {dit_name}'s trained max ({max_s:g}s)")
+            seconds = float(max_s)
         # sigma_max governs every generation's schedule start; when guide audio is
         # present (a2a), init_noise_level overrides it (parent-repo gradio semantics).
         sigma_max = float(init_noise) if a2a_audio else float(sigma_max)
@@ -471,7 +480,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 prompt = gr.Textbox(label="Prompt", lines=2,
                                     placeholder="e.g. 'Impending tribal, epic orchestral buildup'")
                 with gr.Row():
-                    seconds = gr.Slider(label="Seconds", minimum=1, maximum=120,
+                    seconds = gr.Slider(label="Seconds", minimum=1,
+                                        maximum=MAX_SECONDS.get(initial_dit, 120),
                                         value=default_seconds, step=1)
                     steps = gr.Slider(label="Steps", minimum=1, maximum=16,
                                       value=default_steps, step=1)
@@ -517,7 +527,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 timing = gr.HTML()
                 error_box = gr.HTML()
 
-        dit_dd.change(on_dit_change, inputs=[dit_dd], outputs=[decoder_dd])
+        dit_dd.change(on_dit_change, inputs=[dit_dd, seconds],
+                      outputs=[decoder_dd, seconds])
 
         def on_seconds_change(sec):
             return gr.update(maximum=sec), gr.update(maximum=sec)

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -386,8 +386,18 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
 
 # ── HTML rendering (inline handlers only — gradio HTML runs attributes, not
 # <script> tags) ────────────────────────────────────────────────────────────
-_JS_PAUSE_OTHERS = ("var t=this;document.querySelectorAll('audio').forEach("
-                    "function(o){if(o!==t)o.pause();});")
+# One-at-a-time playback. Chrome does NOT stop a playing <audio> when it's
+# removed from the DOM (verified via CDP: swapped-out elements keep playing as
+# detached ghosts), and querySelectorAll can't see detached nodes — so every
+# player registers itself in window._sa3All on play, and pause-others sweeps
+# that registry (reaching ghosts) plus the document. Entries that are detached
+# AND paused drop from the registry so ghosts can be garbage-collected.
+_JS_PAUSE_OTHERS = (
+    "var t=this;var L=window._sa3All=(window._sa3All||[]);"
+    "if(L.indexOf(t)<0)L.push(t);"
+    "L.forEach(function(o){if(o!==t){try{o.pause()}catch(e){}}});"
+    "document.querySelectorAll('audio').forEach(function(o){if(o!==t)o.pause();});"
+    "window._sa3All=L.filter(function(o){return o===t||o.isConnected;});")
 _JS_PLAYHEAD = ("var p=this.closest('.blk').querySelector('.ph');"
                 "if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+'%';")
 # Main-player position ledger (for Hotswap): every timeupdate/play/pause stamps
@@ -688,7 +698,9 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         enc_note = f"encode {t['enc_ms']:.0f} ms{cached_tag} ·&nbsp; " if t.get("enc_ms") else ""
         apg_note = f" (apg {apg:g})" if apg != 1.0 else ""
         cfg_note = f"cfg {cfg:g}{apg_note} ·&nbsp; " if cfg != 1.0 else ""
+        prompt_disp = html_lib.escape(prompt) or "<i>(no prompt)</i>"
         timing_html = (
+            f"{prompt_disp} ·&nbsp; "
             f"{load_note}{enc_note}{cfg_note}"
             f"<b>Inference</b>: {t['inference_ms']:.0f} ms "
             f"<span style='color:#888'>(t5={t['t5_ms']:.0f} · sample={t['sample_ms']:.0f} · "
@@ -853,7 +865,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 with gr.Accordion("Output", open=False):
                     output_opts = gr.CheckboxGroup(
                         ["Auto-play", "Auto-download", "Infinite Radio", "Loop", "Hotswap"],
-                        value=["Auto-play"], label="Options")
+                        value=["Auto-play"], label="Playback Options")
                     opts_state = gr.State(["Auto-play"])
                     file_format = gr.Radio(
                         [FORMAT_MP3, FORMAT_WAV] if FFMPEG else [FORMAT_WAV],

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -410,6 +410,23 @@ def _ago(ts) -> str:
     return f"{int(d // 86400)}d ago"
 
 
+def _meta_suffix(entry) -> str:
+    """' · cfg 1.5 · smx 0.92 · audio2audio · inpainting' — only the non-defaults."""
+    parts = []
+    cfg = entry.get("cfg", 1.0)
+    smx = entry.get("smx", 1.0)
+    if cfg != 1.0:
+        parts.append(f"cfg {cfg:g}")
+    if smx != 1.0:
+        parts.append(f"smx {smx:g}")
+    mode = entry.get("mode", "")
+    if "a2a" in mode or mode == "audio-to-audio":
+        parts.append("audio2audio")
+    if "inpaint" in mode:
+        parts.append("inpainting")
+    return "".join(f" · {p}" for p in parts)
+
+
 def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=False,
                   bg=None, advance=False):
     """One self-contained player block: audio + caption + seekable spectrogram
@@ -451,7 +468,8 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
                f'<div style="flex:1; min-width:0">{audio_el}</div>'
                f'<div style="flex:1; min-width:0">{spec_core}</div></div>')
         cap = (f'<div style="font-size:0.8em; margin:2px 0; color:#888">'
-               f'{_ago(entry.get("ts"))} · {prompt_disp} · seed {entry["seed"]}</div>')
+               f'{_ago(entry.get("ts"))} · {prompt_disp} · seed {entry["seed"]}'
+               f'{_meta_suffix(entry)}</div>')
         style = f"padding:6px 8px;{' background:' + bg + ';' if bg else ''}"
         return (f'<div class="blk" data-key="{entry["key"]}" style="{style}">'
                 f'{row}{cap}</div>')
@@ -490,7 +508,7 @@ def render_queue_status(entry=None, generating=False):
         body = "generating…"
     elif entry is not None:
         p = html_lib.escape(entry["prompt"]) or "<i>(no prompt)</i>"
-        body = f"ready — {p} · seed {entry['seed']}"
+        body = f"ready — {p} · seed {entry['seed']}{_meta_suffix(entry)}"
     else:
         return ""
     return (f'<div style="margin-top:2px; color:#888; font-size:0.85em; opacity:0.7">'
@@ -625,6 +643,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         entry = {
             "key": f"k{time.time_ns()}",
             "ts": time.time(),
+            "cfg": float(cfg),
+            "smx": float(sigma_max),
             "b64": base64.b64encode(out_path.read_bytes()).decode("ascii"),
             "mime": mime,
             "name": out_path.name,

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -478,6 +478,14 @@ def _meta_suffix(entry) -> str:
     return "".join(f" · {p}" for p in parts)
 
 
+def _neg_disp(entry) -> str:
+    """Labeled negative prompt, shown only when it actually acted (cfg != 1)."""
+    neg = (entry.get("neg") or "").strip()
+    if neg and entry.get("cfg", 1.0) != 1.0:
+        return f' · <span style="opacity:0.75">neg: {html_lib.escape(neg)}</span>'
+    return ""
+
+
 def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=False,
                   bg=None, advance=False, loop=False, hotswap=False):
     """One self-contained player block: audio + caption + seekable spectrogram
@@ -543,7 +551,7 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
                f'<div style="flex:1; min-width:0">{audio_el}</div>'
                f'<div style="flex:1; min-width:0">{spec_core}</div></div>')
         cap = (f'<div style="font-size:0.8em; margin:2px 0; color:#888">'
-               f'{_ago(entry.get("ts"))} · {prompt_disp} · seed {entry["seed"]}'
+               f'{_ago(entry.get("ts"))} · {prompt_disp}{_neg_disp(entry)} · seed {entry["seed"]}'
                f'{_meta_suffix(entry)}</div>')
         style = f"padding:6px 8px;{' background:' + bg + ';' if bg else ''}"
         return (f'<div class="blk" data-key="{entry["key"]}" style="{style}">'
@@ -575,7 +583,7 @@ def render_queue_status(entry=None, generating=False):
         body = "generating…"
     elif entry is not None:
         p = html_lib.escape(entry["prompt"]) or "<i>(no prompt)</i>"
-        body = f"ready — {p} · seed {entry['seed']}{_meta_suffix(entry)}"
+        body = f"ready — {p}{_neg_disp(entry)} · seed {entry['seed']}{_meta_suffix(entry)}"
     else:
         return ""
     return (f'<div style="margin-top:2px; padding:6px 10px; '
@@ -699,8 +707,10 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         apg_note = f" (apg {apg:g})" if apg != 1.0 else ""
         cfg_note = f"cfg {cfg:g}{apg_note} ·&nbsp; " if cfg != 1.0 else ""
         prompt_disp = html_lib.escape(prompt) or "<i>(no prompt)</i>"
+        neg_disp = (f' · <span style="opacity:0.75">neg: {html_lib.escape(negative_prompt.strip())}</span>'
+                    if negative_prompt and negative_prompt.strip() and cfg != 1.0 else "")
         timing_html = (
-            f"{prompt_disp} ·&nbsp; "
+            f"{prompt_disp}{neg_disp} ·&nbsp; "
             f"{load_note}{enc_note}{cfg_note}"
             f"<b>Inference</b>: {t['inference_ms']:.0f} ms "
             f"<span style='color:#888'>(t5={t['t5_ms']:.0f} · sample={t['sample_ms']:.0f} · "
@@ -717,6 +727,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             "key": f"k{time.time_ns()}",
             "ts": time.time(),
             "dit": dit_name,
+            "neg": (negative_prompt or "").strip(),
             "cfg": float(cfg),
             "smx": float(sigma_max),
             "path": str(out_path),

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -107,7 +107,8 @@ def verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed) -> str:
     base = condense_prompt(prompt)
     if negative_prompt and negative_prompt.strip():
         base += ".neg-" + condense_prompt(negative_prompt.strip())
-    base += f".cfg{cfg:g}"
+    if cfg != 1.0:
+        base += f".cfg{cfg:g}"
     if sigma_max != 1.0:
         base += f".smx{sigma_max:g}"
     return f"{base}.{seed}"
@@ -384,11 +385,14 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         # Permissive by design: a generation should succeed with whatever IS set.
         # Half-configured features are ignored with a visible note, never an error.
         notes = []
+        # blank or -1 → random seed, kept small (1-9999) for readability
         try:
-            seed = int(seed_text.strip()) if seed_text and seed_text.strip() else _random.randint(0, 2**31 - 1)
+            seed = int(seed_text.strip()) if seed_text and seed_text.strip() else -1
         except ValueError:
-            seed = _random.randint(0, 2**31 - 1)
-            notes.append(f"seed wasn't an integer — used random seed {seed}")
+            seed = -1
+            notes.append("seed wasn't an integer — used a random one")
+        if seed == -1:
+            seed = _random.randint(1, 9999)
         # backstop for API callers bypassing the slider maxima
         max_s = MAX_SECONDS.get(dit_name, 120)
         if seconds > max_s:
@@ -463,7 +467,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             f"decode={t['decode_ms']:.0f})</span> ·&nbsp; "
             f"<b>{t['realtime']:.1f}× realtime</b> ·&nbsp; "
             f"<b>seed</b>: <code>{seed}</code> ·&nbsp; "
-            f"<b>T_lat</b>: {t['T_lat']} ·&nbsp; <b>samples</b>: {t['samples']}"
+            f"<b>seq_len</b>: {t['T_lat']} ·&nbsp; <b>samples</b>: {t['samples']}"
         )
         if notes:
             timing_html = ("".join(f"<div style='color:#fa3; font-size:0.85em'>note: {n}</div>"
@@ -522,10 +526,6 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                                               value=0, step=0.5)
                         inp_end = gr.Slider(label="End (s)", minimum=0, maximum=120,
                                             value=0, step=0.5)
-                    gr.Markdown(
-                        "<span style='color:#888; font-size:0.85em'>Reads best with CFG ≥ 5 and a "
-                        "contrasting prompt. Combinable with audio-to-audio: the regenerated span "
-                        "then starts from the guide audio instead of noise.</span>")
 
             with gr.Column(scale=2):
                 gr.Markdown("**Audio**")
@@ -551,8 +551,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
 
         gr.Markdown(
             "<p style='color:#888; font-size:0.85em'>"
-            "WAVs saved under <code>output/gradio/</code> as "
-            "<code>prompt[.neg-…].cfg…[.smx…].seed.wav</code> (kept forever). "
+            "WAVs saved under <code>output/gradio/</code>. "
             "DiT runs fp16 (MLX canonical), codecs fp32.</p>"
         )
 

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -6,12 +6,18 @@ generation mode wired (the TRT one only exposes text-to-audio):
     memory, LRU-evicted — first switch loads weights, subsequent instant)
   - CFG 0-10 next to seconds/steps (0 = negative prompt takes over, 0.5 = halfway
     between prompts, 1 = off, >1 = extrapolate) + negative prompt/APG under Advanced
-  - Audio-to-audio: guide audio + σmax slider (whole clip starts from its latents)
+  - Audio-to-audio: guide audio + init_noise_level (whole clip starts from its
+    latents); global sigma_max under Advanced for prompt-only generations
   - Inpainting: separate reference audio + start/end range sliders (kept bit-exact
     outside the range). Combinable with a2a: the regenerated span then starts
     from the guide audio instead of noise.
-  - Spectrogram display: 3-band tinted stereo mel spectrogram (numpy port —
-    no torch), rendered inline alongside the audio
+  - Spectrogram-as-player: 3-band tinted stereo mel spectrogram (numpy port — no
+    torch) with a white playhead; click to seek. Only one audio plays at a time.
+  - History: previous generations in a scroll panel (newest on top, scroll
+    position anchored while new items arrive), each replayable.
+  - Output options: Auto-play, Auto-download, Infinite Radio (pre-generates the
+    next clip while the current one plays, swaps it in when playback ends),
+    MP3 (V0, via ffmpeg) or WAV saving.
 
 Launch:
     ./sa3-gradio                  # share=True by default, sm-music + same-s
@@ -21,6 +27,7 @@ Launch:
 from __future__ import annotations
 import argparse
 import base64
+import html as html_lib
 import math
 import re
 import shutil
@@ -108,7 +115,7 @@ def condense_prompt(prompt: str) -> str:
 
 def verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed) -> str:
     """prompt[.neg-…].cfg{scale}[.smx{σ}].{seed} — matches the main repo's
-    gradio 'verbose' file naming."""
+    gradio 'verbose' file naming (cfg segment only when cfg != 1)."""
     base = condense_prompt(prompt)
     if negative_prompt and negative_prompt.strip():
         base += ".neg-" + condense_prompt(negative_prompt.strip())
@@ -361,6 +368,92 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
     return audio_np, t
 
 
+# ── HTML rendering (inline handlers only — gradio HTML runs attributes, not
+# <script> tags) ────────────────────────────────────────────────────────────
+_JS_PAUSE_OTHERS = ("var t=this;document.querySelectorAll('audio').forEach("
+                    "function(o){if(o!==t)o.pause();});")
+_JS_PLAYHEAD = ("var p=this.closest('.blk').querySelector('.ph');"
+                "if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+'%';")
+_JS_SEEK = ("var a=this.closest('.blk').querySelector('audio');"
+            "var r=this.getBoundingClientRect();"
+            "if(a&&a.duration){a.currentTime=(event.clientX-r.left)/r.width*a.duration;a.play();}")
+_JS_PROMOTE = ("var b=document.getElementById('sa3-promote');"
+               "if(b){(b.tagName==='BUTTON'?b:b.querySelector('button')||b).click();}")
+# Scroll anchoring for the history panel: onscroll continuously records which
+# item sits at the viewport top (+offset); after every re-render a hidden
+# bootstrap <img onerror> restores that anchor — stick-to-top when at top,
+# otherwise keep hovering over the same old item as new ones prepend.
+_JS_SCROLL_RECORD = (
+    "var c=this,k=null,off=0,ch=c.querySelectorAll('[data-key]');"
+    "for(var i=0;i<ch.length;i++){if(ch[i].offsetTop+ch[i].offsetHeight>c.scrollTop)"
+    "{k=ch[i].getAttribute('data-key');off=ch[i].offsetTop-c.scrollTop;break}}"
+    "window._sa3S={atTop:c.scrollTop<8,key:k,off:off};")
+_JS_SCROLL_RESTORE = (
+    "var c=document.getElementById('sa3-hist');var s=window._sa3S||{};"
+    "if(c){var el=s.key?c.querySelector('[data-key=&quot;'+s.key+'&quot;]'):null;"
+    "if(el&&!s.atTop){c.scrollTop=el.offsetTop-(s.off||0)}else{c.scrollTop=0}}"
+    "this.remove();")
+
+
+def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=False):
+    """One self-contained player block: audio + caption + seekable spectrogram
+    with playhead. Global one-at-a-time playback via onplay pause-others."""
+    attrs = f'onplay="{_JS_PAUSE_OTHERS}" ontimeupdate="{_JS_PLAYHEAD}"'
+    if autodl:
+        js_name = entry["name"].replace("\\", "").replace("'", "\\'")
+        attrs += (' oncanplay="if(!this.dataset.dld){this.dataset.dld=1;'
+                  "var l=document.createElement('a');l.href=this.src;"
+                  f"l.download='{js_name}';l.click();}}\"")
+    if radio:
+        attrs += f' onended="{_JS_PROMOTE}"'
+    auto = "autoplay " if autoplay else ""
+    audio_el = (f'<audio controls {auto}style="width:100%" {attrs} '
+                f'src="data:{entry["mime"]};base64,{entry["b64"]}"></audio>')
+    prompt_disp = html_lib.escape(entry["prompt"]) or "<i>(no prompt)</i>"
+    if small:
+        cap = (f'<div style="font-size:0.8em; margin:2px 0; color:#888">'
+               f'{prompt_disp} · seed {entry["seed"]} · <code>{html_lib.escape(entry["name"])}</code></div>')
+    else:
+        cap = (f'<div style="font-size:0.85em; margin:4px 0; color:#888">'
+               f'{entry["size_mb"]:.1f} MB · {entry["mode"]} · saved as '
+               f'<code>{html_lib.escape(entry["name"])}</code></div>')
+    spec = ""
+    if entry.get("spec_b64"):
+        height = "height:64px;" if small else ""
+        spec = (f'<div style="position:relative; cursor:pointer" onclick="{_JS_SEEK}">'
+                f'<img src="data:image/png;base64,{entry["spec_b64"]}" '
+                f'style="width:100%; {height} display:block; image-rendering:pixelated; '
+                f'border:1px solid #333" alt="spectrogram"/>'
+                f'<div class="ph" style="position:absolute; top:0; bottom:0; left:0%; width:2px; '
+                f'background:#fff; pointer-events:none; box-shadow:0 0 4px rgba(0,0,0,.8)"></div>'
+                f'</div>')
+        if not small:
+            spec += ('<div style="font-size:0.75em; color:#666; margin-top:2px">'
+                     '3-band tinted stereo mel · red=bass / green=mid / blue=high · '
+                     'L top, R bottom · click to seek</div>')
+    style = "margin-bottom:12px; padding-bottom:8px; border-bottom:1px solid #333;" if small else ""
+    return (f'<div class="blk" data-key="{entry["key"]}" style="{style}">'
+            f'{audio_el}{cap}{spec}</div>')
+
+
+def render_history(hist):
+    if not hist:
+        return ""
+    items = "".join(render_player(e, small=True) for e in hist)
+    boot = f'<img src="data:," style="display:none" onerror="{_JS_SCROLL_RESTORE}"/>'
+    return (f'<div style="font-weight:600; margin-top:14px">Previous generations ({len(hist)})</div>'
+            f'<div id="sa3-hist" onscroll="{_JS_SCROLL_RECORD}" '
+            f'style="max-height:480px; overflow-y:auto; position:relative; margin-top:6px; '
+            f'padding-right:6px">{boot}{items}</div>')
+
+
+def render_queued(entry):
+    if entry is None:
+        return ""
+    return ('<div style="font-weight:600; margin-top:14px">Queued next ▶</div>'
+            + render_player(entry, small=True))
+
+
 # ── Gradio UI ──────────────────────────────────────────────────────────────
 def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
              default_seconds: float, default_steps: int):
@@ -382,11 +475,12 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         return (gr.update(value=DEFAULT_DECODERS.get(dit_name, "same-s")),
                 gr.update(maximum=max_s, value=min(cur_seconds, max_s)))
 
-    def generate(dit_name, decoder_name, prompt, negative_prompt,
-                 seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
-                 a2a_audio, inpaint_audio, inp_start, inp_end,
-                 output_opts, file_format):
-        err = lambda m: ("", "", f"<span style='color:#f88'>{m}</span>")
+    def _generate_entry(dit_name, decoder_name, prompt, negative_prompt,
+                        seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
+                        a2a_audio, inpaint_audio, inp_start, inp_end,
+                        output_opts, file_format):
+        """Run one generation and package it as a history entry.
+        Returns (entry, None) or (None, error_message)."""
         prompt = (prompt or "").strip()
         # Permissive by design: a generation should succeed with whatever IS set.
         # Half-configured features are ignored with a visible note, never an error.
@@ -423,6 +517,12 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         elif inp_end > inp_start:
             notes.append("inpaint range ignored — no reference audio uploaded")
 
+        opts = output_opts or []
+        if ("Infinite Radio" in opts and seed_text and seed_text.strip()
+                and seed_text.strip() != "-1"):
+            notes.append("Infinite Radio with a fixed seed repeats the same clip — "
+                         "clear the seed for endless variety")
+
         mode = ("a2a+inpaint" if (a2a_audio and inpaint_range) else
                 "inpaint" if inpaint_range else
                 "audio-to-audio" if a2a_audio else "text-to-audio")
@@ -434,9 +534,9 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 float(sigma_max), a2a_audio or None, inpaint_audio or None,
                 inpaint_range)
         except Exception as e:
-            return err(f"error: {type(e).__name__}: {e}")
+            return None, f"error: {type(e).__name__}: {e}"
         if not np.isfinite(audio_np).all():
-            return err("error: model produced non-finite audio (try a higher σmax or different seed)")
+            return None, "error: model produced non-finite audio (try a higher σmax or different seed)"
 
         pcm = (np.clip(audio_np, -1, 1) * 32767.0).astype(np.int16).T   # (T, 2)
         basename = verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed)
@@ -453,55 +553,14 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 out_path, mime = mp3_path, "audio/mpeg"
             else:
                 notes.append("mp3 encode failed — saved WAV instead")
-        b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
-        # Audio + spectrogram in ONE block so inline handlers can couple them:
-        # the audio's timeupdate drives the white playhead; clicking the
-        # spectrogram seeks (gradio HTML runs attributes, not <script> tags).
-        opts = output_opts or []
-        autoplay = "autoplay " if "Auto-play" in opts else ""
-        extra_attrs = ""
-        if "Auto-download" in opts:
-            js_name = out_path.name.replace("\\", "").replace("'", "\\'")
-            extra_attrs += (' oncanplay="if(!this.dataset.dld){this.dataset.dld=1;'
-                            "var l=document.createElement('a');l.href=this.src;"
-                            f"l.download='{js_name}';l.click();}}\"")
-        if "Infinite Radio" in opts:
-            extra_attrs += (' onended="var b=document.getElementById(\'sa3-generate\');'
-                            "if(b){(b.tagName==='BUTTON'?b:b.querySelector('button')||b).click();}\"")
-            if seed_text and seed_text.strip() and seed_text.strip() != "-1":
-                notes.append("Infinite Radio with a fixed seed repeats the same clip — "
-                             "clear the seed for endless variety")
-        audio_el = (
-            f'<audio controls {autoplay}style="width:100%" '
-            f'ontimeupdate="var p=this.parentNode.querySelector(\'.ph\');'
-            f'if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+\'%\';"'
-            f'{extra_attrs} '
-            f'src="data:{mime};base64,{b64}"></audio>'
-            f'<div style="font-size:0.85em; margin:4px 0; color:#888">'
-            f'{out_path.stat().st_size/1e6:.1f} MB · {mode} · saved as <code>{out_path.name}</code></div>'
-        )
+
+        spec_b64 = None
         try:
             spec_png = render_spectrogram_png(pcm, sample_rate=SAMPLE_RATE,
                                               width=1200, height=240)
             spec_b64 = base64.b64encode(spec_png).decode("ascii")
-            spec_el = (
-                f'<div style="position:relative; cursor:pointer" '
-                f'onclick="var a=this.parentNode.querySelector(\'audio\');'
-                f'var r=this.getBoundingClientRect();'
-                f'if(a&&a.duration){{a.currentTime=(event.clientX-r.left)/r.width*a.duration;a.play();}}">'
-                f'<img src="data:image/png;base64,{spec_b64}" '
-                f'style="width:100%; display:block; image-rendering:pixelated; border:1px solid #333" '
-                f'alt="spectrogram"/>'
-                f'<div class="ph" style="position:absolute; top:0; bottom:0; left:0%; width:2px; '
-                f'background:#fff; pointer-events:none; box-shadow:0 0 4px rgba(0,0,0,.8)"></div>'
-                f'</div>'
-                f'<div style="font-size:0.75em; color:#666; margin-top:2px">'
-                f'3-band tinted stereo mel · red=bass / green=mid / blue=high · L top, R bottom · '
-                f'click to seek</div>'
-            )
         except Exception as e:
-            spec_el = f"<span style='color:#fa3'>spectrogram failed: {type(e).__name__}: {e}</span>"
-        player_html = f"<div>{audio_el}{spec_el}</div>"
+            notes.append(f"spectrogram failed: {type(e).__name__}: {e}")
 
         load_note = (f"DiT-load {t['dit_load_ms']:.0f} ms ·&nbsp; "
                      if t.get("dit_load_ms", 0) > 100 else "")
@@ -519,7 +578,85 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         if notes:
             timing_html = ("".join(f"<div style='color:#fa3; font-size:0.85em'>note: {n}</div>"
                                    for n in notes) + timing_html)
-        return player_html, timing_html, ""
+
+        entry = {
+            "key": f"k{time.time_ns()}",
+            "b64": base64.b64encode(out_path.read_bytes()).decode("ascii"),
+            "mime": mime,
+            "name": out_path.name,
+            "size_mb": out_path.stat().st_size / 1e6,
+            "mode": mode,
+            "prompt": prompt,
+            "seed": seed,
+            "spec_b64": spec_b64,
+            "timing": timing_html,
+        }
+        return entry, None
+
+    def _present(state, entry, opts, *, force_autoplay=False):
+        """Make `entry` the current clip (previous current moves to history top)
+        and render all output panels."""
+        if state["current"] is not None:
+            state["history"].insert(0, state["current"])
+        state["current"] = entry
+        main = render_player(entry,
+                             autoplay=force_autoplay or "Auto-play" in opts,
+                             autodl="Auto-download" in opts,
+                             radio="Infinite Radio" in opts)
+        return (main, entry["timing"], "",
+                render_history(state["history"]),
+                render_queued(state["queued"]), state)
+
+    def generate(dit_name, decoder_name, prompt, negative_prompt,
+                 seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
+                 a2a_audio, inpaint_audio, inp_start, inp_end,
+                 output_opts, file_format, state):
+        entry, err_msg = _generate_entry(
+            dit_name, decoder_name, prompt, negative_prompt, seconds, steps,
+            seed_text, cfg, apg, sigma_max, init_noise, a2a_audio,
+            inpaint_audio, inp_start, inp_end, output_opts, file_format)
+        if entry is None:
+            return (gr.update(), gr.update(),
+                    f"<span style='color:#f88'>{err_msg}</span>",
+                    gr.update(), gr.update(), state)
+        # a manual Generate makes any queued clip stale (settings may have changed);
+        # the chained pregen refills it when Infinite Radio is on
+        state["queued"] = None
+        return _present(state, entry, output_opts or [])
+
+    def promote(dit_name, decoder_name, prompt, negative_prompt,
+                seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
+                a2a_audio, inpaint_audio, inp_start, inp_end,
+                output_opts, file_format, state):
+        """Infinite Radio: swap the pre-generated clip in when playback ends.
+        Falls back to a full generate if the queue is empty."""
+        q = state.get("queued")
+        if q is None:
+            return generate(dit_name, decoder_name, prompt, negative_prompt,
+                            seconds, steps, seed_text, cfg, apg, sigma_max,
+                            init_noise, a2a_audio, inpaint_audio, inp_start,
+                            inp_end, output_opts, file_format, state)
+        state["queued"] = None
+        return _present(state, q, output_opts or [], force_autoplay=True)
+
+    def pregen(dit_name, decoder_name, prompt, negative_prompt,
+               seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
+               a2a_audio, inpaint_audio, inp_start, inp_end,
+               output_opts, file_format, state):
+        """Chained after generate/promote: pre-generate the NEXT clip while the
+        current one plays (Infinite Radio only)."""
+        if "Infinite Radio" not in (output_opts or []):
+            state["queued"] = None
+            return "", state
+        entry, err_msg = _generate_entry(
+            dit_name, decoder_name, prompt, negative_prompt, seconds, steps,
+            seed_text, cfg, apg, sigma_max, init_noise, a2a_audio,
+            inpaint_audio, inp_start, inp_end, output_opts, file_format)
+        if entry is None:
+            return (f"<div style='color:#f88; font-size:0.85em'>queue: {err_msg}</div>",
+                    state)
+        state["queued"] = entry
+        return render_queued(entry), state
 
     with gr.Blocks(title="SA3 MLX") as demo:
         gr.Markdown(
@@ -528,6 +665,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             "(upload + σmax), inpainting (upload + range). Models cache in unified "
             "memory — first use of a model loads weights, subsequent runs are instant."
         )
+        st = gr.State({"current": None, "queued": None, "history": []})
         with gr.Row():
             with gr.Column(scale=3):
                 with gr.Row():
@@ -550,6 +688,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                                   max_lines=1, value="")
                 generate_btn = gr.Button("Generate", variant="primary", size="lg",
                                          elem_id="sa3-generate")
+                promote_btn = gr.Button("", visible=False, elem_id="sa3-promote")
 
                 with gr.Accordion("Advanced", open=False):
                     with gr.Row():
@@ -589,6 +728,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 output_player = gr.HTML()
                 timing = gr.HTML()
                 error_box = gr.HTML()
+                queued_html = gr.HTML()
+                history_html = gr.HTML()
 
         dit_dd.change(on_dit_change, inputs=[dit_dd, seconds],
                       outputs=[decoder_dd, seconds])
@@ -597,12 +738,29 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             return gr.update(maximum=sec), gr.update(maximum=sec)
         seconds.change(on_seconds_change, inputs=[seconds], outputs=[inp_start, inp_end])
 
-        generate_btn.click(generate,
-                           inputs=[dit_dd, decoder_dd, prompt, negative_prompt,
-                                   seconds, steps, seed, cfg, apg, sigma_global,
-                                   sigma_slider, a2a_audio, inpaint_audio,
-                                   inp_start, inp_end, output_opts, file_format],
-                           outputs=[output_player, timing, error_box])
+        ctrl_inputs = [dit_dd, decoder_dd, prompt, negative_prompt,
+                       seconds, steps, seed, cfg, apg, sigma_global,
+                       sigma_slider, a2a_audio, inpaint_audio,
+                       inp_start, inp_end, output_opts, file_format]
+        main_outputs = [output_player, timing, error_box, queued_html, history_html, st]
+
+        # NB: _present returns (player, timing, err, history, queued, state) —
+        # map onto components in that order.
+        def _reorder(fn):
+            def wrapped(*args):
+                player, tim, err_, hist, queued, state = fn(*args)
+                return player, tim, err_, queued, hist, state
+            wrapped.__name__ = fn.__name__
+            return wrapped
+
+        generate_btn.click(_reorder(generate), inputs=ctrl_inputs + [st],
+                           outputs=main_outputs
+                           ).then(pregen, inputs=ctrl_inputs + [st],
+                                  outputs=[queued_html, st])
+        promote_btn.click(_reorder(promote), inputs=ctrl_inputs + [st],
+                          outputs=main_outputs
+                          ).then(pregen, inputs=ctrl_inputs + [st],
+                                 outputs=[queued_html, st])
 
         gr.Markdown(
             "<p style='color:#888; font-size:0.85em'>"

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -23,6 +23,8 @@ import argparse
 import base64
 import math
 import re
+import shutil
+import subprocess
 import sys
 import time
 import wave
@@ -53,6 +55,9 @@ from spec import render_spectrogram_png  # noqa: E402
 OUTPUT_DIR = REPO / "output" / "gradio"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 MIN_SIGMA = 0.01
+# MP3 (V0) saving needs ffmpeg; without it we save WAV and hide the choice.
+FFMPEG = shutil.which("ffmpeg") is not None
+FORMAT_MP3, FORMAT_WAV = "Save to MP3 (V0)", "Save to WAV"
 DEFAULT_DECODERS = {name: cfg["default_decoder"] for name, cfg in DIT_CHOICES.items()}
 # Trained max clip length per model (repo README model table).
 MAX_SECONDS = {"sm-music": 120, "sm-sfx": 120, "medium": 380}
@@ -379,7 +384,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
 
     def generate(dit_name, decoder_name, prompt, negative_prompt,
                  seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
-                 a2a_audio, inpaint_audio, inp_start, inp_end):
+                 a2a_audio, inpaint_audio, inp_start, inp_end,
+                 output_opts, file_format):
         err = lambda m: ("", "", f"<span style='color:#f88'>{m}</span>")
         prompt = (prompt or "").strip()
         # Permissive by design: a generation should succeed with whatever IS set.
@@ -433,17 +439,44 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             return err("error: model produced non-finite audio (try a higher σmax or different seed)")
 
         pcm = (np.clip(audio_np, -1, 1) * 32767.0).astype(np.int16).T   # (T, 2)
-        out_path = OUTPUT_DIR / f"{verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed)}.wav"
+        basename = verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed)
+        out_path = OUTPUT_DIR / f"{basename}.wav"
         _save_wav(pcm, out_path)
+        mime = "audio/wav"
+        if FFMPEG and file_format == FORMAT_MP3:
+            mp3_path = OUTPUT_DIR / f"{basename}.mp3"
+            r = subprocess.run(["ffmpeg", "-y", "-v", "error", "-i", str(out_path),
+                                "-codec:a", "libmp3lame", "-q:a", "0", str(mp3_path)],
+                               capture_output=True)
+            if r.returncode == 0 and mp3_path.exists():
+                out_path.unlink()
+                out_path, mime = mp3_path, "audio/mpeg"
+            else:
+                notes.append("mp3 encode failed — saved WAV instead")
         b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
         # Audio + spectrogram in ONE block so inline handlers can couple them:
         # the audio's timeupdate drives the white playhead; clicking the
         # spectrogram seeks (gradio HTML runs attributes, not <script> tags).
+        opts = output_opts or []
+        autoplay = "autoplay " if "Auto-play" in opts else ""
+        extra_attrs = ""
+        if "Auto-download" in opts:
+            js_name = out_path.name.replace("\\", "").replace("'", "\\'")
+            extra_attrs += (' oncanplay="if(!this.dataset.dld){this.dataset.dld=1;'
+                            "var l=document.createElement('a');l.href=this.src;"
+                            f"l.download='{js_name}';l.click();}}\"")
+        if "Infinite Radio" in opts:
+            extra_attrs += (' onended="var b=document.getElementById(\'sa3-generate\');'
+                            "if(b){(b.tagName==='BUTTON'?b:b.querySelector('button')||b).click();}\"")
+            if seed_text and seed_text.strip() and seed_text.strip() != "-1":
+                notes.append("Infinite Radio with a fixed seed repeats the same clip — "
+                             "clear the seed for endless variety")
         audio_el = (
-            f'<audio controls autoplay style="width:100%" '
+            f'<audio controls {autoplay}style="width:100%" '
             f'ontimeupdate="var p=this.parentNode.querySelector(\'.ph\');'
-            f'if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+\'%\';" '
-            f'src="data:audio/wav;base64,{b64}"></audio>'
+            f'if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+\'%\';"'
+            f'{extra_attrs} '
+            f'src="data:{mime};base64,{b64}"></audio>'
             f'<div style="font-size:0.85em; margin:4px 0; color:#888">'
             f'{out_path.stat().st_size/1e6:.1f} MB · {mode} · saved as <code>{out_path.name}</code></div>'
         )
@@ -515,7 +548,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                                     value=1.0, step=0.1)
                 seed = gr.Textbox(label="Seed (optional, blank = random)",
                                   max_lines=1, value="")
-                generate_btn = gr.Button("Generate", variant="primary", size="lg")
+                generate_btn = gr.Button("Generate", variant="primary", size="lg",
+                                         elem_id="sa3-generate")
 
                 with gr.Accordion("Advanced", open=False):
                     with gr.Row():
@@ -541,6 +575,15 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                         inp_end = gr.Slider(label="End (s)", minimum=0, maximum=120,
                                             value=0, step=0.5)
 
+                with gr.Accordion("Output", open=False):
+                    output_opts = gr.CheckboxGroup(
+                        ["Auto-play", "Auto-download", "Infinite Radio"],
+                        value=["Auto-play"], label="Options")
+                    file_format = gr.Radio(
+                        [FORMAT_MP3, FORMAT_WAV] if FFMPEG else [FORMAT_WAV],
+                        value=FORMAT_MP3 if FFMPEG else FORMAT_WAV,
+                        label="Format", visible=FFMPEG)
+
             with gr.Column(scale=2):
                 gr.Markdown("**Output**")
                 output_player = gr.HTML()
@@ -558,7 +601,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                            inputs=[dit_dd, decoder_dd, prompt, negative_prompt,
                                    seconds, steps, seed, cfg, apg, sigma_global,
                                    sigma_slider, a2a_audio, inpaint_audio,
-                                   inp_start, inp_end],
+                                   inp_start, inp_end, output_opts, file_format],
                            outputs=[output_player, timing, error_box])
 
         gr.Markdown(

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 import argparse
 import base64
 import math
+import re
 import sys
 import time
-import uuid
 import wave
 from pathlib import Path
 
@@ -52,7 +52,6 @@ from spec import render_spectrogram_png  # noqa: E402
 
 OUTPUT_DIR = REPO / "output" / "gradio"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-KEEP_RECENT_N = 20
 MIN_SIGMA = 0.01
 DEFAULT_DECODERS = {name: cfg["default_decoder"] for name, cfg in DIT_CHOICES.items()}
 # Trained max clip length per model (repo README model table).
@@ -95,13 +94,23 @@ def read_audio_any(path: str) -> np.ndarray:
         return np.ascontiguousarray(y, dtype=np.float32)
 
 
-def _prune_old_outputs():
-    wavs = sorted(OUTPUT_DIR.glob("*.wav"), key=lambda p: p.stat().st_mtime, reverse=True)
-    for old in wavs[KEEP_RECENT_N:]:
-        try:
-            old.unlink()
-        except OSError:
-            pass
+def condense_prompt(prompt: str) -> str:
+    """Prompt → filename fragment (the main repo's verbose-naming rule):
+    filesystem-special characters become hyphens, capped at 150 chars."""
+    prompt = re.sub(r'[\\/:*?"<>|]', '-', prompt)[:150]
+    return prompt or "_"
+
+
+def verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed) -> str:
+    """prompt[.neg-…].cfg{scale}[.smx{σ}].{seed} — matches the main repo's
+    gradio 'verbose' file naming."""
+    base = condense_prompt(prompt)
+    if negative_prompt and negative_prompt.strip():
+        base += ".neg-" + condense_prompt(negative_prompt.strip())
+    base += f".cfg{cfg:g}"
+    if sigma_max != 1.0:
+        base += f".smx{sigma_max:g}"
+    return f"{base}.{seed}"
 
 
 def _save_wav(pcm_int16, out_path):
@@ -420,15 +429,14 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             return err("error: model produced non-finite audio (try a higher σmax or different seed)")
 
         pcm = (np.clip(audio_np, -1, 1) * 32767.0).astype(np.int16).T   # (T, 2)
-        out_path = OUTPUT_DIR / f"sa3-{uuid.uuid4().hex[:10]}.wav"
+        out_path = OUTPUT_DIR / f"{verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed)}.wav"
         _save_wav(pcm, out_path)
-        _prune_old_outputs()
         b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
         audio_html = (
             f'<audio controls autoplay style="width:100%" '
             f'src="data:audio/wav;base64,{b64}"></audio>'
             f'<div style="font-size:0.85em; margin-top:4px; color:#888">'
-            f'{out_path.stat().st_size/1e6:.1f} MB · {mode} · right-click to download</div>'
+            f'{out_path.stat().st_size/1e6:.1f} MB · {mode} · saved as <code>{out_path.name}</code></div>'
         )
         try:
             spec_png = render_spectrogram_png(pcm, sample_rate=SAMPLE_RATE,
@@ -543,7 +551,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
 
         gr.Markdown(
             "<p style='color:#888; font-size:0.85em'>"
-            f"WAVs saved under <code>output/gradio/</code> (rotates after {KEEP_RECENT_N} files). "
+            "WAVs saved under <code>output/gradio/</code> as "
+            "<code>prompt[.neg-…].cfg…[.smx…].seed.wav</code> (kept forever). "
             "DiT runs fp16 (MLX canonical), codecs fp32.</p>"
         )
 

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -34,6 +34,7 @@ import shutil
 import subprocess
 import sys
 import time
+import urllib.parse
 import wave
 from pathlib import Path
 
@@ -501,8 +502,12 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
                   "while(n&&!n.classList.contains('blk'))n=n.nextElementSibling;"
                   "if(n){var a=n.querySelector('audio');if(a)a.play();}\"")
     auto = "autoplay " if autoplay else ""
+    # Serve audio via gradio's file route instead of a data: URI — the URL ends
+    # with the real (verbose) filename, so right-click "Save audio as…" offers
+    # it instead of download.mp3, and the page stays light as history grows.
+    src = "gradio_api/file=" + urllib.parse.quote(entry["path"], safe="/")
     audio_el = (f'<audio controls {auto}style="width:100%" {attrs} '
-                f'src="data:{entry["mime"]};base64,{entry["b64"]}"></audio>')
+                f'src="{src}"></audio>')
     prompt_disp = html_lib.escape(entry["prompt"]) or "<i>(no prompt)</i>"
 
     spec_core = ""
@@ -528,16 +533,13 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
         return (f'<div class="blk" data-key="{entry["key"]}" style="{style}">'
                 f'{row}{cap}</div>')
 
-    cap = (f'<div style="font-size:0.85em; margin:4px 0; color:#888">'
-           f'{entry["size_mb"]:.1f} MB · {entry["mode"]} · saved as '
-           f'<code>{html_lib.escape(entry["name"])}</code></div>')
     spec = spec_core
     if spec_core:
         spec += ('<div style="font-size:0.75em; color:#666; margin-top:2px">'
                  '3-band tinted stereo mel · red=bass / green=mid / blue=high · '
                  'L top, R bottom · click to seek</div>')
     return (f'<div class="blk" data-key="{entry["key"]}">'
-            f'{audio_el}{cap}{spec}</div>')
+            f'{audio_el}{spec}</div>')
 
 
 def render_history(hist, advance=False, loop=False):
@@ -704,7 +706,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             "dit": dit_name,
             "cfg": float(cfg),
             "smx": float(sigma_max),
-            "b64": base64.b64encode(out_path.read_bytes()).decode("ascii"),
+            "path": str(out_path),
             "mime": mime,
             "name": out_path.name,
             "size_mb": out_path.stat().st_size / 1e6,
@@ -919,6 +921,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         )
 
     demo.queue(max_size=16).launch(share=share, server_name="0.0.0.0",
+                                   allowed_paths=[str(OUTPUT_DIR)],
                                    prevent_thread_lock=False, show_error=True)
 
 

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -772,13 +772,20 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 a2a_audio, inpaint_audio, inp_start, inp_end,
                 output_opts, file_format, state):
         """Infinite Radio: swap the pre-generated clip in when playback ends.
-        Falls back to a full generate if the queue is empty."""
+        Falls back to a full generate if the queue is empty. Either way the
+        next track ALWAYS autoplays — Auto-play only governs whether a clip
+        starts when nothing was playing; radio transitions are continuations."""
         q = state.get("queued")
         if q is None:
-            return generate(dit_name, decoder_name, prompt, negative_prompt,
-                            seconds, steps, seed_text, cfg, apg, sigma_max,
-                            init_noise, a2a_audio, inpaint_audio, inp_start,
-                            inp_end, output_opts, file_format, state)
+            entry, err_msg = _generate_entry(
+                dit_name, decoder_name, prompt, negative_prompt, seconds, steps,
+                seed_text, cfg, apg, sigma_max, init_noise, a2a_audio,
+                inpaint_audio, inp_start, inp_end, output_opts, file_format)
+            if entry is None:
+                return (gr.update(), gr.update(),
+                        f"<span style='color:#f88'>{err_msg}</span>",
+                        gr.update(), gr.update(), state)
+            q = entry
         state["queued"] = None
         return _present(state, q, output_opts or [],
                         render_queue_status(generating=True), force_autoplay=True)

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -145,6 +145,11 @@ _dit_lru: list[tuple[str, int]] = []
 _DIT_CACHE_MAX = 2
 _dec_cache: dict[str, tuple] = {}                        # decoder -> (model, chunk_fn, chunk_cfg)
 _enc_cache: dict[str, tuple] = {}                        # decoder -> (model, pad_modulo)
+# Encoded-latent cache: rerunning a2a/inpainting with the same input audio skips
+# the encoder entirely. Keyed on the file's CONTENT hash (gradio re-uploads get
+# fresh temp paths) + encoder + latent length; values are ~160 KB fp32 arrays.
+_latent_cache: dict[tuple, np.ndarray] = {}
+_LATENT_CACHE_MAX = 32
 
 
 def get_t5() -> T5Gemma:
@@ -243,8 +248,15 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
     mx.eval(cross_attn, global_cond)
     t["cond_ms"] = (time.time() - t0) * 1000
 
-    # 3a. encode the provided audio inputs → latents (each is optional)
+    # 3a. encode the provided audio inputs → latents (each is optional).
+    # Latents are memoized by (file content, encoder, T_lat) so re-running
+    # a2a/inpainting with the same input audio skips the encoder.
     def encode_audio(path):
+        import hashlib
+        ck = (hashlib.sha1(Path(path).read_bytes()).hexdigest(), decoder_name, T_lat)
+        if ck in _latent_cache:
+            t["enc_cached"] = t.get("enc_cached", 0) + 1
+            return mx.array(_latent_cache[ck]).astype(dtype)
         enc_model, pad_mod = get_encoder(decoder_name)
         enc_T_lat = T_lat
         if (T_lat * 16) % pad_mod != 0:
@@ -258,6 +270,9 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
         patches_np = patch_audio(audio_np[None, ...], patch_size=256)
         lat = enc_model(mx.array(patches_np))[..., :T_lat]
         mx.eval(lat)
+        while len(_latent_cache) >= _LATENT_CACHE_MAX:
+            _latent_cache.pop(next(iter(_latent_cache)))
+        _latent_cache[ck] = np.array(lat.astype(mx.float32))
         return lat.astype(dtype)
 
     a2a_latents = None      # start-point guide (whole clip)
@@ -630,7 +645,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
 
         load_note = (f"DiT-load {t['dit_load_ms']:.0f} ms ·&nbsp; "
                      if t.get("dit_load_ms", 0) > 100 else "")
-        enc_note = f"encode {t['enc_ms']:.0f} ms ·&nbsp; " if t.get("enc_ms") else ""
+        cached_tag = " (cached)" if t.get("enc_cached") else ""
+        enc_note = f"encode {t['enc_ms']:.0f} ms{cached_tag} ·&nbsp; " if t.get("enc_ms") else ""
         apg_note = f" (apg {apg:g})" if apg != 1.0 else ""
         cfg_note = f"cfg {cfg:g}{apg_note} ·&nbsp; " if cfg != 1.0 else ""
         timing_html = (

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -392,12 +392,16 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
 # player registers itself in window._sa3All on play, and pause-others sweeps
 # that registry (reaching ghosts) plus the document. Entries that are detached
 # AND paused drop from the registry so ghosts can be garbage-collected.
+# A DETACHED element's play event must never silence the living player (the
+# swap can briefly leave a superseded copy whose pending play() resolves late).
 _JS_PAUSE_OTHERS = (
+    "if(this.isConnected){"
     "var t=this;var L=window._sa3All=(window._sa3All||[]);"
     "if(L.indexOf(t)<0)L.push(t);"
     "L.forEach(function(o){if(o!==t){try{o.pause()}catch(e){}}});"
     "document.querySelectorAll('audio').forEach(function(o){if(o!==t)o.pause();});"
-    "window._sa3All=L.filter(function(o){return o===t||o.isConnected;});")
+    "window._sa3All=L.filter(function(o){return o===t||o.isConnected;});}"
+    "else{this.pause();}")
 _JS_PLAYHEAD = ("var p=this.closest('.blk').querySelector('.ph');"
                 "if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+'%';")
 # Main-player position ledger (for Hotswap): every timeupdate/play/pause stamps
@@ -411,14 +415,40 @@ _JS_PLAYHEAD = ("var p=this.closest('.blk').querySelector('.ph');"
 #    handler reads it.
 _JS_POS_RECORD = ("if(this.isConnected&&!(this.dataset.hs==='1'&&!this.dataset.hsd))"
                   "{window._sa3Pos={t:this.currentTime,playing:!this.paused,ts:Date.now()};}")
+# timeupdate variant: a PAUSED element only fires timeupdate on seeks — e.g. the
+# resume handler's own currentTime assignment. Stamping playing:false there
+# poisons the ledger for any second render of the same clip (gradio sometimes
+# renders a component update twice), which froze the handoff chain. While
+# paused, only real pause events may write.
+_JS_POS_RECORD_TU = ("if(this.isConnected&&!this.paused&&"
+                     "!(this.dataset.hs==='1'&&!this.dataset.hsd))"
+                     "{window._sa3Pos={t:this.currentTime,playing:true,ts:Date.now()};}")
+# Resilient play: Chrome's autoplay policy can reject programmatic play() once
+# the transient user activation from the Generate click has expired (seconds),
+# leaving the clip correctly positioned but paused. Try, retry shortly after,
+# and as a last resort arm a one-shot listener so the user's next click or
+# keypress anywhere resumes playback.
+# Every attempt re-checks isConnected: a superseded (detached) element must
+# never revive itself from a queued retry and fight the current player.
+_JS_TRY_PLAY = (
+    "var A=this;A.play().catch(function(){setTimeout(function(){"
+    "if(!A.isConnected)return;"
+    "A.play().catch(function(){console.warn('play blocked by autoplay policy — "
+    "will resume on next interaction');"
+    "var f=function(){if(A.isConnected)A.play();"
+    "document.removeEventListener('pointerdown',f,true);"
+    "document.removeEventListener('keydown',f,true);};"
+    "document.addEventListener('pointerdown',f,true);"
+    "document.addEventListener('keydown',f,true);});},150);});")
 # Hotswap resume: if the previous main audio was playing when this one arrived,
 # jump to its position (+ the split-second since the last stamp) and keep going;
 # beyond the new clip's duration -> start at zero. Guarded (hsd) so it applies
 # once, on whichever of loadedmetadata/canplay fires first.
-_JS_HOTSWAP = ("if(this.dataset.hs==='1'&&!this.dataset.hsd&&this.duration){"
+_JS_HOTSWAP = ("if(this.isConnected&&this.dataset.hs==='1'&&!this.dataset.hsd&&this.duration){"
                "this.dataset.hsd=1;var s=window._sa3Pos;"
+               "this.dataset.dbg=s?(s.playing?'playing@'+s.t.toFixed(2):'notplaying@'+s.t.toFixed(2)):'noledger';"
                "if(s&&s.playing){var tt=s.t+(Date.now()-s.ts)/1000;"
-               "this.currentTime=(tt<this.duration)?tt:0;this.play();}}")
+               "this.currentTime=(tt<this.duration)?tt:0;" + _JS_TRY_PLAY + "}}")
 _JS_SEEK = ("var a=this.closest('.blk').querySelector('audio');"
             "var r=this.getBoundingClientRect();"
             "if(a&&a.duration){a.currentTime=(event.clientX-r.left)/r.width*a.duration;a.play();}")
@@ -502,10 +532,15 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
     else:
         attrs = (f'onplay="{_JS_PAUSE_OTHERS}{_JS_POS_RECORD}" '
                  f'onpause="{_JS_POS_RECORD}" '
-                 f'ontimeupdate="{_JS_PLAYHEAD}{_JS_POS_RECORD}"')
+                 f'ontimeupdate="{_JS_PLAYHEAD}{_JS_POS_RECORD_TU}"')
     if hotswap and not small:
         attrs += f' data-hs="1" onloadedmetadata="{_JS_HOTSWAP}"'
         on_canplay.append(_JS_HOTSWAP)   # fallback if loadedmetadata already passed
+    if autoplay and not small:
+        # the autoplay attribute is subject to the same policy — rescue a
+        # policy-paused clip (radio transitions, long generations)
+        on_canplay.append("if(this.paused&&!(this.dataset.hs==='1'&&!this.dataset.hsd))"
+                          "{" + _JS_TRY_PLAY + "}")
     if autodl:
         js_name = entry["name"].replace("\\", "").replace("'", "\\'")
         on_canplay.append("if(!this.dataset.dld){this.dataset.dld=1;"

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -380,7 +380,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
     def generate(dit_name, decoder_name, prompt, negative_prompt,
                  seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
                  a2a_audio, inpaint_audio, inp_start, inp_end):
-        err = lambda m: ("", "", "", f"<span style='color:#f88'>{m}</span>")
+        err = lambda m: ("", "", f"<span style='color:#f88'>{m}</span>")
         prompt = (prompt or "").strip()
         # Permissive by design: a generation should succeed with whatever IS set.
         # Half-configured features are ignored with a visible note, never an error.
@@ -436,25 +436,39 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         out_path = OUTPUT_DIR / f"{verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed)}.wav"
         _save_wav(pcm, out_path)
         b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
-        audio_html = (
+        # Audio + spectrogram in ONE block so inline handlers can couple them:
+        # the audio's timeupdate drives the white playhead; clicking the
+        # spectrogram seeks (gradio HTML runs attributes, not <script> tags).
+        audio_el = (
             f'<audio controls autoplay style="width:100%" '
+            f'ontimeupdate="var p=this.parentNode.querySelector(\'.ph\');'
+            f'if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+\'%\';" '
             f'src="data:audio/wav;base64,{b64}"></audio>'
-            f'<div style="font-size:0.85em; margin-top:4px; color:#888">'
+            f'<div style="font-size:0.85em; margin:4px 0; color:#888">'
             f'{out_path.stat().st_size/1e6:.1f} MB · {mode} · saved as <code>{out_path.name}</code></div>'
         )
         try:
             spec_png = render_spectrogram_png(pcm, sample_rate=SAMPLE_RATE,
                                               width=1200, height=240)
             spec_b64 = base64.b64encode(spec_png).decode("ascii")
-            spec_html = (
+            spec_el = (
+                f'<div style="position:relative; cursor:pointer" '
+                f'onclick="var a=this.parentNode.querySelector(\'audio\');'
+                f'var r=this.getBoundingClientRect();'
+                f'if(a&&a.duration){{a.currentTime=(event.clientX-r.left)/r.width*a.duration;a.play();}}">'
                 f'<img src="data:image/png;base64,{spec_b64}" '
-                f'style="width:100%; image-rendering:pixelated; border:1px solid #333" '
+                f'style="width:100%; display:block; image-rendering:pixelated; border:1px solid #333" '
                 f'alt="spectrogram"/>'
+                f'<div class="ph" style="position:absolute; top:0; bottom:0; left:0%; width:2px; '
+                f'background:#fff; pointer-events:none; box-shadow:0 0 4px rgba(0,0,0,.8)"></div>'
+                f'</div>'
                 f'<div style="font-size:0.75em; color:#666; margin-top:2px">'
-                f'3-band tinted stereo mel · red=bass / green=mid / blue=high · L top, R bottom</div>'
+                f'3-band tinted stereo mel · red=bass / green=mid / blue=high · L top, R bottom · '
+                f'click to seek</div>'
             )
         except Exception as e:
-            spec_html = f"<span style='color:#fa3'>spectrogram failed: {type(e).__name__}: {e}</span>"
+            spec_el = f"<span style='color:#fa3'>spectrogram failed: {type(e).__name__}: {e}</span>"
+        player_html = f"<div>{audio_el}{spec_el}</div>"
 
         load_note = (f"DiT-load {t['dit_load_ms']:.0f} ms ·&nbsp; "
                      if t.get("dit_load_ms", 0) > 100 else "")
@@ -472,7 +486,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         if notes:
             timing_html = ("".join(f"<div style='color:#fa3; font-size:0.85em'>note: {n}</div>"
                                    for n in notes) + timing_html)
-        return audio_html, spec_html, timing_html, ""
+        return player_html, timing_html, ""
 
     with gr.Blocks(title="SA3 MLX") as demo:
         gr.Markdown(
@@ -528,10 +542,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                                             value=0, step=0.5)
 
             with gr.Column(scale=2):
-                gr.Markdown("**Audio**")
-                output_audio = gr.HTML()
-                gr.Markdown("**Spectrogram**")
-                output_spec = gr.HTML()
+                gr.Markdown("**Output**")
+                output_player = gr.HTML()
                 timing = gr.HTML()
                 error_box = gr.HTML()
 
@@ -547,7 +559,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                                    seconds, steps, seed, cfg, apg, sigma_global,
                                    sigma_slider, a2a_audio, inpaint_audio,
                                    inp_start, inp_end],
-                           outputs=[output_audio, output_spec, timing, error_box])
+                           outputs=[output_player, timing, error_box])
 
         gr.Markdown(
             "<p style='color:#888; font-size:0.85em'>"

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -23,7 +23,6 @@ import argparse
 import base64
 import math
 import sys
-import threading
 import time
 import uuid
 import wave
@@ -57,11 +56,18 @@ KEEP_RECENT_N = 20
 MIN_SIGMA = 0.01
 DEFAULT_DECODERS = {name: cfg["default_decoder"] for name, cfg in DIT_CHOICES.items()}
 
-# gradio runs handlers on anyio worker threads; MLX keeps its default stream
-# per-thread, so a handler can land on a thread with no GPU stream registered
-# ("There is no Stream(gpu, 0) in current thread"). One generation at a time,
-# and every generation re-pins the default device on its thread.
-_GEN_LOCK = threading.Lock()
+# MLX ≥0.31 registers GPU streams PER THREAD (ThreadLocalStream) while gradio
+# runs each handler on a rotating anyio worker thread — cross-thread MLX use
+# then dies with "There is no Stream(gpu, 0) in current thread". The categorical
+# fix: ALL MLX work (pre-warm + every generation) runs on one dedicated owner
+# thread; handlers submit to it and wait. This also serializes generations.
+import concurrent.futures as _cf
+_MLX_EXECUTOR = _cf.ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx")
+
+
+def mlx_call(fn, *args, **kwargs):
+    """Run fn on the MLX owner thread and return its result (re-raises errors)."""
+    return _MLX_EXECUTOR.submit(fn, *args, **kwargs).result()
 
 
 def read_audio_any(path: str) -> np.ndarray:
@@ -180,7 +186,7 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
       - both: the inpainted span regenerates FROM the a2a guide instead of pure noise
     """
     t = {}
-    mx.set_default_device(mx.gpu)   # thread-local in MLX — see _GEN_LOCK note
+    mx.set_default_device(mx.gpu)   # belt-and-braces; normally on the MLX owner thread
     dtype = mx.float16   # MLX canonical DiT dtype
     T_lat = max(1, math.ceil(seconds * SAMPLE_RATE / SAMPLES_PER_LATENT))
 
@@ -344,11 +350,15 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
     import gradio as gr
     import random as _random
 
-    # Pre-warm the initial pipeline so the first click is fast.
+    # Pre-warm the initial pipeline so the first click is fast — ON the MLX
+    # owner thread, so all stream/model state lives where generations run.
     warm_T = max(1, math.ceil(default_seconds * SAMPLE_RATE / SAMPLES_PER_LATENT))
     print(f"  pre-warming {initial_dit}+{initial_decoder} (T_lat={warm_T})...")
-    get_t5(); get_conditioner(initial_dit)
-    get_dit(initial_dit, warm_T, mx.float16); get_decoder(initial_decoder)
+
+    def _warm():
+        get_t5(); get_conditioner(initial_dit)
+        get_dit(initial_dit, warm_T, mx.float16); get_decoder(initial_decoder)
+    mlx_call(_warm)
 
     def on_dit_change(dit_name):
         return gr.update(value=DEFAULT_DECODERS.get(dit_name, "same-s"))
@@ -385,12 +395,12 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 "inpaint" if inpaint_range else
                 "audio-to-audio" if a2a_audio else "text-to-audio")
         try:
-            with _GEN_LOCK:
-                audio_np, t = run_generation(
-                    dit_name, decoder_name, prompt, negative_prompt or "",
-                    float(seconds), int(steps), seed, float(cfg), float(apg),
-                    float(sigma_max), a2a_audio or None, inpaint_audio or None,
-                    inpaint_range)
+            audio_np, t = mlx_call(
+                run_generation,
+                dit_name, decoder_name, prompt, negative_prompt or "",
+                float(seconds), int(steps), seed, float(cfg), float(apg),
+                float(sigma_max), a2a_audio or None, inpaint_audio or None,
+                inpaint_range)
         except Exception as e:
             return err(f"error: {type(e).__name__}: {e}")
         if not np.isfinite(audio_np).all():

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -441,10 +441,15 @@ def render_history(hist):
         return ""
     items = "".join(render_player(e, small=True) for e in hist)
     boot = f'<img src="data:," style="display:none" onerror="{_JS_SCROLL_RESTORE}"/>'
-    return (f'<div style="font-weight:600; margin-top:14px">Previous generations ({len(hist)})</div>'
+    # darker grey box so the history reads as subdued background material
+    return (f'<div style="margin-top:14px; background:rgba(0,0,0,0.3); '
+            f'border:1px solid #2a2a2a; border-radius:8px; padding:10px 12px">'
+            f'<div style="font-weight:600; font-size:0.85em; color:#999">'
+            f'Previous generations ({len(hist)})</div>'
             f'<div id="sa3-hist" onscroll="{_JS_SCROLL_RECORD}" '
-            f'style="max-height:480px; overflow-y:auto; position:relative; margin-top:6px; '
-            f'padding-right:6px">{boot}{items}</div>')
+            f'style="max-height:480px; overflow-y:auto; position:relative; margin-top:8px; '
+            f'padding-right:6px; opacity:0.85">{boot}{items}</div>'
+            f'</div>')
 
 
 def render_queue_status(entry=None, generating=False):

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -450,6 +450,9 @@ def _meta_suffix(entry) -> str:
     smx = entry.get("smx", 1.0)
     mode = entry.get("mode", "")
     is_a2a = "a2a" in mode or mode == "audio-to-audio"
+    dit = entry.get("dit", "")
+    if dit:
+        parts.append({"medium": "med", "sm-music": "sm-mus", "sm-sfx": "sm-sfx"}.get(dit, dit))
     if cfg != 1.0:
         parts.append(f"cfg {cfg:g}")
     if smx != 1.0:
@@ -698,6 +701,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         entry = {
             "key": f"k{time.time_ns()}",
             "ts": time.time(),
+            "dit": dit_name,
             "cfg": float(cfg),
             "smx": float(sigma_max),
             "b64": base64.b64encode(out_path.read_bytes()).decode("ascii"),

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -743,8 +743,11 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                     decoder_dd = gr.Dropdown(label="Decoder (codec)",
                                              choices=list(DECODER_CHOICES.keys()),
                                              value=initial_decoder, scale=1)
-                prompt = gr.Textbox(label="Prompt", lines=2,
-                                    placeholder="e.g. 'Impending tribal, epic orchestral buildup'")
+                with gr.Row():
+                    prompt = gr.Textbox(label="Prompt", lines=2, scale=6,
+                                        placeholder="e.g. 'Impending tribal, epic orchestral buildup'")
+                    seed = gr.Textbox(label="Seed (optional)", max_lines=1, value="",
+                                      scale=1, min_width=80)
                 with gr.Row():
                     seconds = gr.Slider(label="Seconds", minimum=1,
                                         maximum=MAX_SECONDS.get(initial_dit, 120),
@@ -753,8 +756,6 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                                       value=default_steps, step=1)
                     cfg = gr.Slider(label="CFG", minimum=0.0, maximum=10.0,
                                     value=1.0, step=0.1)
-                seed = gr.Textbox(label="Seed (optional, blank = random)",
-                                  max_lines=1, value="")
                 generate_btn = gr.Button("Generate", variant="primary", size="lg",
                                          elem_id="sa3-generate")
                 promote_btn = gr.Button("", elem_id="sa3-promote")   # CSS-hidden, DOM-present

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -395,9 +395,26 @@ _JS_SCROLL_RESTORE = (
     "this.remove();")
 
 
-def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=False):
+def _ago(ts) -> str:
+    if not ts:
+        return ""
+    d = max(0.0, time.time() - ts)
+    if d < 10:
+        return "just now"
+    if d < 60:
+        return f"{int(d)}s ago"
+    if d < 3600:
+        return f"{int(d // 60)}m ago"
+    if d < 86400:
+        return f"{int(d // 3600)}h ago"
+    return f"{int(d // 86400)}d ago"
+
+
+def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=False,
+                  bg=None):
     """One self-contained player block: audio + caption + seekable spectrogram
-    with playhead. Global one-at-a-time playback via onplay pause-others."""
+    with playhead. Global one-at-a-time playback via onplay pause-others.
+    small: audio + spectrogram side by side (half width each), 'Xm ago' caption."""
     attrs = f'onplay="{_JS_PAUSE_OTHERS}" ontimeupdate="{_JS_PLAYHEAD}"'
     if autodl:
         js_name = entry["name"].replace("\\", "").replace("'", "\\'")
@@ -410,46 +427,54 @@ def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=Fal
     audio_el = (f'<audio controls {auto}style="width:100%" {attrs} '
                 f'src="data:{entry["mime"]};base64,{entry["b64"]}"></audio>')
     prompt_disp = html_lib.escape(entry["prompt"]) or "<i>(no prompt)</i>"
-    if small:
-        cap = (f'<div style="font-size:0.8em; margin:2px 0; color:#888">'
-               f'{prompt_disp} · seed {entry["seed"]} · <code>{html_lib.escape(entry["name"])}</code></div>')
-    else:
-        cap = (f'<div style="font-size:0.85em; margin:4px 0; color:#888">'
-               f'{entry["size_mb"]:.1f} MB · {entry["mode"]} · saved as '
-               f'<code>{html_lib.escape(entry["name"])}</code></div>')
-    spec = ""
+
+    spec_core = ""
     if entry.get("spec_b64"):
-        height = "height:64px;" if small else ""
-        spec = (f'<div style="position:relative; cursor:pointer" onclick="{_JS_SEEK}">'
-                f'<img src="data:image/png;base64,{entry["spec_b64"]}" '
-                f'style="width:100%; {height} display:block; image-rendering:pixelated; '
-                f'border:1px solid #333" alt="spectrogram"/>'
-                f'<div class="ph" style="position:absolute; top:0; bottom:0; left:0%; width:2px; '
-                f'background:#fff; pointer-events:none; box-shadow:0 0 4px rgba(0,0,0,.8)"></div>'
-                f'</div>')
-        if not small:
-            spec += ('<div style="font-size:0.75em; color:#666; margin-top:2px">'
-                     '3-band tinted stereo mel · red=bass / green=mid / blue=high · '
-                     'L top, R bottom · click to seek</div>')
-    style = "margin-bottom:12px; padding-bottom:8px; border-bottom:1px solid #333;" if small else ""
-    return (f'<div class="blk" data-key="{entry["key"]}" style="{style}">'
+        height = "height:56px;" if small else ""
+        spec_core = (f'<div style="position:relative; cursor:pointer" onclick="{_JS_SEEK}">'
+                     f'<img src="data:image/png;base64,{entry["spec_b64"]}" '
+                     f'style="width:100%; {height} display:block; image-rendering:pixelated; '
+                     f'border:1px solid #333" alt="spectrogram"/>'
+                     f'<div class="ph" style="position:absolute; top:0; bottom:0; left:0%; '
+                     f'width:2px; background:#fff; pointer-events:none; '
+                     f'box-shadow:0 0 4px rgba(0,0,0,.8)"></div>'
+                     f'</div>')
+
+    if small:
+        row = (f'<div style="display:flex; gap:8px; align-items:center">'
+               f'<div style="flex:1; min-width:0">{audio_el}</div>'
+               f'<div style="flex:1; min-width:0">{spec_core}</div></div>')
+        cap = (f'<div style="font-size:0.8em; margin:2px 0; color:#888">'
+               f'{_ago(entry.get("ts"))} · {prompt_disp} · seed {entry["seed"]} · '
+               f'<code>{html_lib.escape(entry["name"])}</code></div>')
+        style = f"padding:6px 8px;{' background:' + bg + ';' if bg else ''}"
+        return (f'<div class="blk" data-key="{entry["key"]}" style="{style}">'
+                f'{row}{cap}</div>')
+
+    cap = (f'<div style="font-size:0.85em; margin:4px 0; color:#888">'
+           f'{entry["size_mb"]:.1f} MB · {entry["mode"]} · saved as '
+           f'<code>{html_lib.escape(entry["name"])}</code></div>')
+    spec = spec_core
+    if spec_core:
+        spec += ('<div style="font-size:0.75em; color:#666; margin-top:2px">'
+                 '3-band tinted stereo mel · red=bass / green=mid / blue=high · '
+                 'L top, R bottom · click to seek</div>')
+    return (f'<div class="blk" data-key="{entry["key"]}">'
             f'{audio_el}{cap}{spec}</div>')
 
 
 def render_history(hist):
     if not hist:
         return ""
-    items = "".join(render_player(e, small=True) for e in hist)
+    # zebra striping instead of separators: light grey on every other row
+    items = "".join(
+        render_player(e, small=True, bg="rgba(127,127,127,0.12)" if i % 2 else None)
+        for i, e in enumerate(hist))
     boot = f'<img src="data:," style="display:none" onerror="{_JS_SCROLL_RESTORE}"/>'
-    # darker grey box so the history reads as subdued background material
-    return (f'<div style="margin-top:14px; background:rgba(0,0,0,0.3); '
-            f'border:1px solid #2a2a2a; border-radius:8px; padding:10px 12px">'
-            f'<div style="font-weight:600; font-size:0.85em; color:#999">'
-            f'Previous generations ({len(hist)})</div>'
+    return (f'<div style="font-weight:600; margin-top:14px">Previous generations ({len(hist)})</div>'
             f'<div id="sa3-hist" onscroll="{_JS_SCROLL_RECORD}" '
-            f'style="max-height:480px; overflow-y:auto; position:relative; margin-top:8px; '
-            f'padding-right:6px; opacity:0.85">{boot}{items}</div>'
-            f'</div>')
+            f'style="max-height:480px; overflow-y:auto; position:relative; margin-top:6px; '
+            f'padding-right:6px">{boot}{items}</div>')
 
 
 def render_queue_status(entry=None, generating=False):
@@ -593,6 +618,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
 
         entry = {
             "key": f"k{time.time_ns()}",
+            "ts": time.time(),
             "b64": base64.b64encode(out_path.read_bytes()).decode("ascii"),
             "mime": mime,
             "name": out_path.name,

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -411,16 +411,19 @@ def _ago(ts) -> str:
 
 
 def _meta_suffix(entry) -> str:
-    """' · cfg 1.5 · smx 0.92 · audio2audio · inpainting' — only the non-defaults."""
+    """' · cfg 1.5 · noise 0.92 · audio2audio · inpainting' — only the non-defaults.
+    The sigma tag reads 'noise' for a2a runs (it IS the init_noise_level there),
+    'smx' otherwise."""
     parts = []
     cfg = entry.get("cfg", 1.0)
     smx = entry.get("smx", 1.0)
+    mode = entry.get("mode", "")
+    is_a2a = "a2a" in mode or mode == "audio-to-audio"
     if cfg != 1.0:
         parts.append(f"cfg {cfg:g}")
     if smx != 1.0:
-        parts.append(f"smx {smx:g}")
-    mode = entry.get("mode", "")
-    if "a2a" in mode or mode == "audio-to-audio":
+        parts.append(f"{'noise' if is_a2a else 'smx'} {smx:g}")
+    if is_a2a:
         parts.append("audio2audio")
     if "inpaint" in mode:
         parts.append("inpainting")
@@ -511,7 +514,9 @@ def render_queue_status(entry=None, generating=False):
         body = f"ready — {p} · seed {entry['seed']}{_meta_suffix(entry)}"
     else:
         return ""
-    return (f'<div style="margin-top:2px; color:#888; font-size:0.85em; opacity:0.7">'
+    return (f'<div style="margin-top:2px; padding:6px 10px; '
+            f'background:rgba(127,127,127,0.12); border-radius:6px; '
+            f'color:#888; font-size:0.85em">'
             f'<b>Queued next</b> · {body}</div>')
 
 
@@ -626,7 +631,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         load_note = (f"DiT-load {t['dit_load_ms']:.0f} ms ·&nbsp; "
                      if t.get("dit_load_ms", 0) > 100 else "")
         enc_note = f"encode {t['enc_ms']:.0f} ms ·&nbsp; " if t.get("enc_ms") else ""
-        cfg_note = f"cfg {cfg} (apg {apg}) ·&nbsp; " if cfg != 1.0 else ""
+        apg_note = f" (apg {apg:g})" if apg != 1.0 else ""
+        cfg_note = f"cfg {cfg:g}{apg_note} ·&nbsp; " if cfg != 1.0 else ""
         timing_html = (
             f"{load_note}{enc_note}{cfg_note}"
             f"<b>Inference</b>: {t['inference_ms']:.0f} ms "

--- a/optimized/mlx/scripts/spec.py
+++ b/optimized/mlx/scripts/spec.py
@@ -1,0 +1,180 @@
+"""Mel-spectrogram renderer — numpy-only port of the TensorRT release's spec.py.
+
+Same algorithm and constants as optimized/tensorRT/scripts/spec.py (the 3-band
+tinted stereo mel spectrogram from our run dashboards), with the torch pieces
+(STFT, resample, filterbank matmul) rewritten in numpy so the MLX release stays
+torch-free. Numerics match: periodic Hann window, center=True reflect padding,
+Slaney mel scale, librosa-compatible filterbank, linear resample with
+align_corners=False sampling positions.
+
+Exposes render_spectrogram_png(pcm_int16, sample_rate, width, height).
+"""
+from __future__ import annotations
+import io
+import math
+from functools import lru_cache
+
+import numpy as np
+from PIL import Image
+
+
+# 3-band tint
+SPEC_BANDS = [
+    (0, 200, (1.0, 0.0, 0.0)),       # Bass -> Red
+    (200, 1500, (0.0, 1.0, 0.0)),    # Mid  -> Green
+    (1500, 16000, (0.0, 0.0, 1.0)),  # High -> Blue
+]
+_BAND_COLORS = np.array([c for _, _, c in SPEC_BANDS], dtype=np.float32)
+
+# Slaney mel-scale constants (linear below 1 kHz, log above), matches librosa default.
+_F_SP = 200.0 / 3
+_MIN_LOG_HZ = 1000.0
+_MIN_LOG_MEL = _MIN_LOG_HZ / _F_SP
+_LOGSTEP = math.log(6.4) / 27.0
+
+
+def _hz_to_mel(hz):
+    hz = np.asarray(hz, dtype=np.float64)
+    log_term = np.log(np.maximum(hz, _MIN_LOG_HZ) / _MIN_LOG_HZ) / _LOGSTEP
+    return np.where(hz >= _MIN_LOG_HZ, _MIN_LOG_MEL + log_term, hz / _F_SP)
+
+
+def _mel_to_hz(mels):
+    mels = np.asarray(mels, dtype=np.float64)
+    return np.where(mels >= _MIN_LOG_MEL,
+                    _MIN_LOG_HZ * np.exp(_LOGSTEP * (mels - _MIN_LOG_MEL)),
+                    _F_SP * mels)
+
+
+def _mel_frequencies(n_mels, fmax, fmin=0.0):
+    return _mel_to_hz(np.linspace(_hz_to_mel(fmin), _hz_to_mel(fmax), n_mels))
+
+
+@lru_cache(maxsize=8)
+def _mel_filterbank(n_mels, n_fft, sr, fmax):
+    pts = _mel_to_hz(np.linspace(_hz_to_mel(0.0), _hz_to_mel(fmax), n_mels + 2))
+    fft_f = np.linspace(0, sr / 2, n_fft // 2 + 1)
+    filt = np.zeros((n_mels, n_fft // 2 + 1), dtype=np.float32)
+    for i in range(n_mels):
+        lo, ce, hi = pts[i], pts[i + 1], pts[i + 2]
+        left = (fft_f - lo) / max(ce - lo, 1e-10)
+        right = (hi - fft_f) / max(hi - ce, 1e-10)
+        filt[i] = np.maximum(0, np.minimum(left, right))
+    enorm = (2.0 / (pts[2:n_mels + 2] - pts[0:n_mels])).astype(np.float32)
+    filt *= enorm[:, None]
+    return filt
+
+
+def _stft_power(y, n_fft, hop):
+    """|STFT|^2 with periodic Hann + center=True reflect pad (torch.stft-compatible).
+    Returns (n_fft//2+1, n_frames) float32."""
+    y = np.asarray(y, dtype=np.float32)
+    pad = n_fft // 2
+    y = np.pad(y, pad, mode="reflect")
+    n_frames = 1 + (len(y) - n_fft) // hop
+    idx = np.arange(n_fft)[None, :] + hop * np.arange(n_frames)[:, None]
+    # periodic Hann (torch.hann_window default), not numpy's symmetric hanning
+    win = (0.5 - 0.5 * np.cos(2.0 * np.pi * np.arange(n_fft) / n_fft)).astype(np.float32)
+    frames = y[idx] * win[None, :]
+    spec = np.fft.rfft(frames, n=n_fft, axis=1)
+    return (spec.real ** 2 + spec.imag ** 2).T.astype(np.float32)
+
+
+def _melspectrogram(y_ch, sr, n_mels=30, fmax=16000, hop_length=2048, n_fft=2048):
+    power = _stft_power(y_ch, n_fft, hop_length)
+    return _mel_filterbank(n_mels, n_fft, sr, fmax) @ power
+
+
+def _power_to_db(S, top_db=80.0):
+    log_spec = 10.0 * np.log10(np.maximum(S, 1e-10))
+    return np.maximum(log_spec - log_spec.max(), -top_db)
+
+
+def _mel_channel(y_ch, sr, n_mels=30):
+    """dB-scaled mel + band-tinted RGB for one mono channel."""
+    S = _melspectrogram(y_ch, sr, n_mels=n_mels, fmax=16000, hop_length=2048)
+
+    S_db = _power_to_db(S)
+    np.clip(S_db, -60, 0, out=S_db)
+    S_db += 60.0
+    S_db /= 60.0
+    np.power(S_db, 0.6, out=S_db)
+
+    mel_f = _mel_frequencies(n_mels, fmax=16000)
+    n_frames = S.shape[1]
+    band_norms = np.empty((3, n_frames), dtype=np.float32)
+    for i, (flo, fhi, _) in enumerate(SPEC_BANDS):
+        mask = (mel_f >= flo) & (mel_f < fhi)
+        if mask.any():
+            power = np.sum(S[mask], axis=0)
+            db = 10.0 * np.log10(power + 1e-10)
+            np.clip(db, -20, None, out=db)
+            db -= -20
+            mx = db.max()
+            if mx > 0:
+                db /= mx
+            band_norms[i] = db
+        else:
+            band_norms[i] = 0.0
+
+    rgb = band_norms.T @ _BAND_COLORS
+    for c in range(3):
+        mx = rgb[:, c].max()
+        if mx > 0:
+            rgb[:, c] /= mx
+
+    return S_db, rgb
+
+
+def _resample_to_32k(pcm_int16, sr_in):
+    """Resample (T, 2) int16 PCM to (2, T') float32 at 32 kHz.
+    Linear interpolation at align_corners=False sample positions (matches the
+    torch.nn.functional.interpolate call in the TRT original)."""
+    target_sr = 32000
+    y = pcm_int16.astype(np.float32).T / 32768.0      # (2, T)
+    if sr_in == target_sr:
+        return y, target_sr
+    in_len = y.shape[-1]
+    new_len = int(round(in_len * target_sr / sr_in))
+    scale = in_len / new_len
+    pos = np.clip((np.arange(new_len, dtype=np.float64) + 0.5) * scale - 0.5, 0, in_len - 1)
+    out = np.stack([np.interp(pos, np.arange(in_len), ch) for ch in y]).astype(np.float32)
+    return out, target_sr
+
+
+def render_spectrogram_png(pcm_int16, sample_rate=44100, width=1200, height=240,
+                           n_mels=30) -> bytes:
+    """Render the 3-band tinted stereo mel spectrogram to PNG bytes.
+
+    Args:
+        pcm_int16: (T, 2) int16 numpy array — stereo PCM.
+        sample_rate: input PCM sample rate (default 44100).
+        width, height: final image size.
+        n_mels: mel filterbank size (30 matches the dashboards).
+
+    Returns: PNG bytes ready to base64 / save / etc.
+    """
+    if pcm_int16.ndim != 2 or pcm_int16.shape[1] != 2:
+        raise ValueError(f"expected (T, 2) PCM, got {pcm_int16.shape}")
+    y, sr = _resample_to_32k(pcm_int16, sample_rate)
+    S_L, rgb_L = _mel_channel(y[0], sr, n_mels=n_mels)
+    S_R, rgb_R = _mel_channel(y[1], sr, n_mels=n_mels)
+
+    nf = min(S_L.shape[1], S_R.shape[1])
+    S_L, S_R = S_L[:, :nf], S_R[:, :nf]
+    rgb_L, rgb_R = rgb_L[:nf], rgb_R[:nf]
+    nm = S_L.shape[0]
+
+    # L channel: flip vertically so bass-band is at bottom.
+    S_L = S_L[::-1]
+
+    img = np.empty((nm * 2, nf, 3), dtype=np.float32)
+    img[:nm] = S_L[:, :, np.newaxis] * rgb_L[np.newaxis, :, :]
+    img[nm:] = S_R[:, :, np.newaxis] * rgb_R[np.newaxis, :, :]
+
+    np.clip(img, 0, 1, out=img)
+    img *= 255
+    pil = Image.fromarray(img.astype(np.uint8)).resize((width, height), Image.LANCZOS)
+    buf = io.BytesIO()
+    pil.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()


### PR DESCRIPTION
Adds a gradio web UI to the MLX release — the Apple-Silicon sibling of `optimized/tensorRT/scripts/sa3_gradio.py`, extended well beyond it. Launch with `./sa3-gradio` (public share link by default, `--no-share` for local).

## Generation
- **All four modes**: text-to-audio; CFG 0–10 (0 = negative prompt takes over, 0.5 = halfway between prompts, >1 = extrapolate; APG applies only in the >1 regime) + labeled negative prompt display; audio-to-audio (guide audio + `init_noise_level`, default 0.92 "fusion"); inpainting (separate reference audio + start/end range sliders) — **a2a and inpainting combine**: the inpainted span regenerates from the guide audio.
- Global `sigma_max` (Advanced) shapes every generation; `init_noise_level` overrides it when guide audio is present (parent-repo gradio semantics).
- Model picker (sm-music / sm-sfx / medium) with per-model max length (120s / 120s / 380s); models hot-swap and cache in unified memory. Encoded latents are memoized by content hash, so re-running a2a/inpainting with the same input skips the encoder.
- Permissive by design: half-configured inputs are ignored with a visible note, never an error.

## Playback
- **Spectrogram-as-player**: 3-band tinted stereo mel (numpy-only port — release stays torch-free), white playhead, click-to-seek, hover tooltip.
- **History**: previous generations in a scroll panel (newest first, scroll-anchored so new arrivals don't yank the view), each replayable, with relative timestamps and full settings captions (seed · model · cfg · noise/smx · modes · neg prompt).
- **Playback options**: Auto-play (governs only idle-start), Auto-download, **Infinite Radio** (pre-generates the next track while the current plays; instant swap on end; mutually exclusive with **Loop**), and **Hotswap** (a new generation splices in at the exact playback position, gapless).
- One audio at a time, globally — including detached elements (Chrome keeps removed audio playing; a registry sweep handles it). The playback engine's invariants (detached elements may neither play nor pause others; paused-seek timeupdates don't write the position ledger) were each verified with an instrumented headless-Chrome CDP harness.
- Save as MP3 (V0, when ffmpeg is present — default) or WAV, with the main repo's verbose file naming; audio served via gradio file routes so right-click save gets real filenames.

## Verified (M4 Pro MacBook Pro)
All modes drive end-to-end through the served endpoints; hotswap/radio/one-at-a-time behaviors verified via CDP-driven browser sessions (deterministic resume across consecutive swaps, single live player census).