### PR TITLE
MLX LoRA: merge-at-load (#57) + underfit support + per-step gating + gradio UI

### DIFF
--- a/optimized/mlx/README.md
+++ b/optimized/mlx/README.md
@@ -98,6 +98,14 @@ Apple Silicon only (MLX is Metal-backed). Python 3.10+. `./install.sh
 ./sa3 --prompt "arabic maqam oud taqsim" --dit medium --decoder same-l \
       --lora ./my_lora.safetensors --lora-strength 1.0 --out maqam.wav
 
+# Per-LoRA strength + sampling-step gating (skipping step 1 often helps).
+# steps= is 1-based inclusive: 2-8, 2- (2..last), -4 (1..4), 3 (just step 3).
+# Step-gated adapters are re-merged in place at the few step boundaries
+# (~80 ms each on medium) — no extra memory, every step runs at full speed.
+./sa3 --prompt "progressive metal instrumental" --dit medium --decoder same-l \
+      --lora plini.safetensors strength=0.8 steps=2- \
+      --lora rain_texture.safetensors steps=-4 --out prog.wav
+
 # Generate + play immediately (afplay; Ctrl-C stops both)
 ./sa3 --prompt "rainforest" --dit sm-sfx --decoder same-s --play
 
@@ -200,8 +208,8 @@ Sample run on **M4 Pro / 48 GB**:
 | `--init-noise-level`  | 1.0      | σmax; 0.4–0.8 typical for variation, 1.0 = full regen, >1 = overshoot |
 | `--inpaint-range`     | —        | `START,END` seconds; regenerate that span, keep the rest              |
 | `--dit-dtype`         | fp16     | DiT compute dtype (decoder always FP32; T5Gemma always fp16)          |
-| `--lora`              | —        | One or more `.safetensors` LoRA adapters merged into the DiT at load (SA3-native or PEFT). Pickle `.ckpt/.pt` is refused. Base must match `--dit` |
-| `--lora-strength`     | 1.0      | Application weight per `--lora` delta; 0 = bit-exact bypass, >1 amplifies |
+| `--lora`              | —        | A `.safetensors` LoRA adapter (SA3-native/underfit or PEFT) with optional `strength=S` and `steps=MIN-MAX` tokens; repeat the flag to stack adapters. Full-range adapters merge at load; step-gated ones re-merge in place at step boundaries. Pickle `.ckpt/.pt` is refused. Base must match `--dit` |
+| `--lora-strength`     | 1.0      | Default strength for adapters without their own `strength=`; 0 = bit-exact bypass, >1 amplifies |
 | `--free-models`       | on       | Progressive model freeing; `--no-free-models` keeps them resident     |
 | `--out`               | out.wav  | Relative → `output/<file>`; absolute → as-is. 16-bit PCM stereo @ 44.1 kHz, trimmed to exactly `--seconds` |
 | `--play`              | off      | After writing, play via `afplay`; Ctrl-C stops both processes         |

--- a/optimized/mlx/README.md
+++ b/optimized/mlx/README.md
@@ -94,6 +94,10 @@ Apple Silicon only (MLX is Metal-backed). Python 3.10+. `./install.sh
 ./sa3 --prompt "ambient drone" --cfg 3.0 --negative-prompt "drums, vocals" \
       --dit sm-music --decoder same-s --out drone.wav
 
+# Apply a LoRA finetune (merged into the DiT at load; base must match --dit)
+./sa3 --prompt "arabic maqam oud taqsim" --dit medium --decoder same-l \
+      --lora ./my_lora.safetensors --lora-strength 1.0 --out maqam.wav
+
 # Generate + play immediately (afplay; Ctrl-C stops both)
 ./sa3 --prompt "rainforest" --dit sm-sfx --decoder same-s --play
 
@@ -196,6 +200,8 @@ Sample run on **M4 Pro / 48 GB**:
 | `--init-noise-level`  | 1.0      | σmax; 0.4–0.8 typical for variation, 1.0 = full regen, >1 = overshoot |
 | `--inpaint-range`     | —        | `START,END` seconds; regenerate that span, keep the rest              |
 | `--dit-dtype`         | fp16     | DiT compute dtype (decoder always FP32; T5Gemma always fp16)          |
+| `--lora`              | —        | One or more `.safetensors` LoRA adapters merged into the DiT at load (SA3-native or PEFT). Pickle `.ckpt/.pt` is refused. Base must match `--dit` |
+| `--lora-strength`     | 1.0      | Application weight per `--lora` delta; 0 = bit-exact bypass, >1 amplifies |
 | `--free-models`       | on       | Progressive model freeing; `--no-free-models` keeps them resident     |
 | `--out`               | out.wav  | Relative → `output/<file>`; absolute → as-is. 16-bit PCM stereo @ 44.1 kHz, trimmed to exactly `--seconds` |
 | `--play`              | off      | After writing, play via `afplay`; Ctrl-C stops both processes         |

--- a/optimized/mlx/models/defs/dit_mlx.py
+++ b/optimized/mlx/models/defs/dit_mlx.py
@@ -304,18 +304,28 @@ def convert_weights_from_torch_ckpt(ckpt_path):
     return out
 
 
-def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False):
+def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
+             lora_paths=None, lora_strength=1.0, lora_log=print):
     """Build MLX DiT and load weights.
 
     weights_path can be either:
       - the sa3-sm-music torch ckpt (slow; converts at load time), OR
       - a pre-converted MLX file (.npz or .safetensors — fast path).
+
+    lora_paths: optional list of LoRA adapters (.safetensors / PEFT dir) to merge
+      into the weights at load time. lora_strength scales every adapter's delta.
+      See models/defs/lora_merge.py.
     """
     p = str(weights_path)
     if p.endswith(".npz") or p.endswith(".safetensors"):
         wd = dict(mx.load(p))
     else:
         wd = convert_weights_from_torch_ckpt(p)
+
+    if lora_paths:
+        from .lora_merge import merge_loras_into_weights
+        stats = merge_loras_into_weights(wd, lora_paths, strength=lora_strength, log=lora_log)
+        lora_log(f"lora: merged {stats['merged']} layer(s) from {stats['adapters']} adapter(s)")
 
     model = DiT(T_lat=T_lat)
     wd_list = [(k, v.astype(dtype)) for k, v in wd.items()]

--- a/optimized/mlx/models/defs/dit_mlx.py
+++ b/optimized/mlx/models/defs/dit_mlx.py
@@ -305,7 +305,8 @@ def convert_weights_from_torch_ckpt(ckpt_path):
 
 
 def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
-             lora_paths=None, lora_strength=1.0, lora_log=print):
+             lora_paths=None, lora_strength=1.0, lora_log=print,
+             lora_specs=None, num_steps=None):
     """Build MLX DiT and load weights.
 
     weights_path can be either:
@@ -315,6 +316,11 @@ def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
     lora_paths: optional list of LoRA adapters (.safetensors / PEFT dir) to merge
       into the weights at load time. lora_strength scales every adapter's delta.
       See models/defs/lora_merge.py.
+    lora_specs: optional list of parsed --lora specs (lora_merge.parse_lora_spec)
+      with per-adapter strength and step range; needs num_steps (the sampling
+      schedule length). Adapters gated to a sub-range of steps are managed by a
+      LoraStepPlan stashed on the returned model as ``model._lora_plan`` — wire
+      its ``.sync`` as the sampler's ``before_step``. Supersedes lora_paths.
     """
     p = str(weights_path)
     if p.endswith(".npz") or p.endswith(".safetensors"):
@@ -322,7 +328,11 @@ def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
     else:
         wd = convert_weights_from_torch_ckpt(p)
 
-    if lora_paths:
+    plan = None
+    if lora_specs:
+        from .lora_merge import prepare_loras
+        plan = prepare_loras(wd, lora_specs, num_steps=num_steps, log=lora_log)
+    elif lora_paths:
         from .lora_merge import merge_loras_into_weights
         stats = merge_loras_into_weights(wd, lora_paths, strength=lora_strength, log=lora_log)
         lora_log(f"lora: merged {stats['merged']} layer(s) from {stats['adapters']} adapter(s)")
@@ -335,6 +345,9 @@ def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
     del wd, wd_list
     import gc; gc.collect()
     mx.eval(model.parameters())
+    if plan is not None:
+        plan.attach(model)
+    model._lora_plan = plan
     if compile_:
         model = mx.compile(model)
     return model

--- a/optimized/mlx/models/defs/dit_mlx_medium.py
+++ b/optimized/mlx/models/defs/dit_mlx_medium.py
@@ -405,11 +405,16 @@ def convert_weights(safetensors_path, out_path=None):
     return out
 
 
-def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False):
+def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
+             lora_paths=None, lora_strength=1.0, lora_log=print):
     """Build MLX DiT and load weights.
 
     weights_path: either the .safetensors (we'll convert in-memory) or a
                   pre-converted .safetensors-mlx file.
+
+    lora_paths: optional list of LoRA adapters (.safetensors / PEFT dir) to merge
+      into the weights at load time. lora_strength scales every adapter's delta.
+      See models/defs/lora_merge.py.
     """
     weights_path = str(weights_path)
     if weights_path.endswith(".safetensors") and ("medium-ARC" in weights_path):
@@ -417,6 +422,11 @@ def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False):
         wd = convert_weights(weights_path, out_path=None)
     else:
         wd = dict(mx.load(weights_path))
+
+    if lora_paths:
+        from .lora_merge import merge_loras_into_weights
+        stats = merge_loras_into_weights(wd, lora_paths, strength=lora_strength, log=lora_log)
+        lora_log(f"lora: merged {stats['merged']} layer(s) from {stats['adapters']} adapter(s)")
 
     model = DiT(T_lat=T_lat)
 

--- a/optimized/mlx/models/defs/dit_mlx_medium.py
+++ b/optimized/mlx/models/defs/dit_mlx_medium.py
@@ -406,7 +406,8 @@ def convert_weights(safetensors_path, out_path=None):
 
 
 def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
-             lora_paths=None, lora_strength=1.0, lora_log=print):
+             lora_paths=None, lora_strength=1.0, lora_log=print,
+             lora_specs=None, num_steps=None):
     """Build MLX DiT and load weights.
 
     weights_path: either the .safetensors (we'll convert in-memory) or a
@@ -415,6 +416,11 @@ def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
     lora_paths: optional list of LoRA adapters (.safetensors / PEFT dir) to merge
       into the weights at load time. lora_strength scales every adapter's delta.
       See models/defs/lora_merge.py.
+    lora_specs: optional list of parsed --lora specs (lora_merge.parse_lora_spec)
+      with per-adapter strength and step range; needs num_steps (the sampling
+      schedule length). Adapters gated to a sub-range of steps are managed by a
+      LoraStepPlan stashed on the returned model as ``model._lora_plan`` — wire
+      its ``.sync`` as the sampler's ``before_step``. Supersedes lora_paths.
     """
     weights_path = str(weights_path)
     if weights_path.endswith(".safetensors") and ("medium-ARC" in weights_path):
@@ -423,7 +429,11 @@ def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
     else:
         wd = dict(mx.load(weights_path))
 
-    if lora_paths:
+    plan = None
+    if lora_specs:
+        from .lora_merge import prepare_loras
+        plan = prepare_loras(wd, lora_specs, num_steps=num_steps, log=lora_log)
+    elif lora_paths:
         from .lora_merge import merge_loras_into_weights
         stats = merge_loras_into_weights(wd, lora_paths, strength=lora_strength, log=lora_log)
         lora_log(f"lora: merged {stats['merged']} layer(s) from {stats['adapters']} adapter(s)")
@@ -439,6 +449,9 @@ def load_dit(weights_path, T_lat=320, dtype=mx.float16, compile_=False,
     del wd, wd_list
     import gc; gc.collect()
     mx.eval(model.parameters())
+    if plan is not None:
+        plan.attach(model)
+    model._lora_plan = plan
 
     if compile_:
         # Compile the model for graph fusion

--- a/optimized/mlx/models/defs/lora_merge.py
+++ b/optimized/mlx/models/defs/lora_merge.py
@@ -389,3 +389,414 @@ def _weight_as_2d(arr):
 
         return w2d, restore
     raise LoraError(f"unexpected weight rank {np_arr.ndim} for a LoRA target")
+
+
+# ── per-step gating (--lora … steps=A-B) ────────────────────────────────────────
+#
+# Every adapter type's per-layer contribution can be written in one closed form
+#
+#     strength·(merged − W0) = strength·(α βᵀ − 1) ⊙ W0  +  B′ @ A′
+#
+# with α (row) / β (col) scale vectors (absent → 1) and rank-r factors B′/A′
+# computed ONCE at load, while the pristine W0 is still in the weight dict.
+# That lets the sampler move between step-sets IN PLACE, with no stored W0:
+#
+#     W(S)  = W0 ⊙ M_S + LR_S      M_S = 1 + Σ_{i∈S} strength_i (α_i β_iᵀ − 1)
+#     W_new = (W_cur − LR_S) · (M_S′ / M_S) + LR_S′
+#
+# computed in float32 and cast back to the model dtype. One transition costs
+# ~26 ms (small DiT) / ~80 ms (medium) — a quarter of one sampling step — and
+# only fires when the active set changes (≤ steps−1 times per generation).
+# Every transition routes through base, so fp16 round-trip drift is bounded;
+# in the one-shot CLI it is negligible. A long-lived host that cycles
+# partial-interval adapters across MANY generations on one cached model should
+# reload weights occasionally (drift grows ~1e-5 rel per boundary, decelerating).
+
+def parse_lora_spec(tokens, default_strength: float = 1.0) -> dict:
+    """Parse one ``--lora`` group: ``PATH [strength=S] [steps=RANGE]``.
+
+    RANGE grammar (1-based, inclusive): ``3`` (just step 3), ``2-8``, ``2-``
+    (2..last), ``-4`` (1..4). Returns ``{"path", "strength", "steps"}`` where
+    ``steps`` is None (all steps) or a raw ``(lo|None, hi|None)`` pair resolved
+    against the actual ``--steps`` by :func:`resolve_steps`.
+    """
+    if not tokens:
+        raise LoraError("--lora needs an adapter path")
+    spec = {"path": tokens[0], "strength": default_strength, "steps": None}
+    for tok in tokens[1:]:
+        key, eq, val = tok.partition("=")
+        if not eq or key not in ("strength", "steps"):
+            raise LoraError(
+                f"--lora: unexpected token {tok!r} — one adapter per --lora flag; "
+                f"options after the path are strength=S and steps=RANGE "
+                f"(e.g. --lora a.safetensors strength=0.8 steps=2-8)"
+            )
+        if key == "strength":
+            try:
+                spec["strength"] = float(val)
+            except ValueError:
+                raise LoraError(f"--lora: bad strength {val!r}") from None
+        else:
+            spec["steps"] = _parse_step_range(val)
+    return spec
+
+
+def _parse_step_range(s: str):
+    def _int(part, what):
+        try:
+            v = int(part)
+        except ValueError:
+            raise LoraError(f"--lora steps={s!r}: {what} is not an integer") from None
+        if v < 1:
+            raise LoraError(f"--lora steps={s!r}: steps are 1-based")
+        return v
+
+    if "-" in s:
+        lo_s, _, hi_s = s.partition("-")
+        lo = _int(lo_s, "min step") if lo_s else None
+        hi = _int(hi_s, "max step") if hi_s else None
+        if lo is None and hi is None:
+            raise LoraError(f"--lora steps={s!r}: empty range")
+    else:
+        lo = hi = _int(s, "step")
+    if lo is not None and hi is not None and lo > hi:
+        raise LoraError(f"--lora steps={s!r}: min > max")
+    return (lo, hi)
+
+
+def resolve_steps(raw, num_steps: int):
+    """Raw 1-based ``(lo|None, hi|None)`` → 0-based inclusive ``(lo0, hi0)``
+    clamped to the schedule. None (no steps= given) covers every step. Returns
+    None when the range misses the schedule entirely."""
+    if raw is None:
+        return (0, num_steps - 1)
+    lo, hi = raw
+    lo0 = (lo or 1) - 1
+    hi0 = min((hi or num_steps) - 1, num_steps - 1)
+    if lo0 > hi0 or lo0 >= num_steps:
+        return None
+    return (lo0, hi0)
+
+
+def _delta_form(W0: np.ndarray, p: dict, adapter_type: str, scaling: float,
+                strength: float):
+    """Closed-form ``(row, col, Bp, Ap)`` float32 for one layer such that
+    ``strength·(merged − W0) == strength·(row·colᵀ − 1)⊙W0 + Bp @ Ap``
+    (row/col None when the type has no magnitude on that axis). Algebraically
+    identical to :func:`_merged_weight`, just refactored around W0."""
+    if adapter_type.endswith("-xs"):
+        rank = p["M_xs"].shape[0]
+        U, V = _svd_bases(W0, rank)
+        B, A = U @ p["M_xs"], V.T
+    else:
+        B, A = p["lora_B"], p["lora_A"]
+    if adapter_type in ("lora", "lora-xs"):
+        return None, None, (strength * scaling) * B, A
+    V_ = W0 + scaling * (B @ A)
+    if adapter_type in ("dora-rows", "dora-rows-xs"):
+        c = np.atleast_1d(np.squeeze(p["magnitude"])) / (np.linalg.norm(V_, axis=1) + 1e-12)
+        return (c.astype(np.float32), None,
+                (strength * scaling) * (c[:, None] * B), A)
+    if adapter_type in ("dora-cols", "dora-cols-xs"):
+        c = np.atleast_1d(np.squeeze(p["magnitude"])) / (np.linalg.norm(V_, axis=0) + 1e-12)
+        return (None, c.astype(np.float32),
+                (strength * scaling) * B, A * c[None, :])
+    if adapter_type in ("bora", "bora-xs"):
+        alpha = p["magnitude_r"] / (np.linalg.norm(V_, axis=1) + 1e-12)
+        inter = alpha[:, None] * V_
+        beta = p["magnitude_c"] / (np.linalg.norm(inter, axis=0) + 1e-12)
+        return (alpha.astype(np.float32), beta.astype(np.float32),
+                (strength * scaling) * (alpha[:, None] * B), A * beta[None, :])
+    raise LoraError(f"unknown adapter_type {adapter_type!r}")
+
+
+def _as2d_mx(w: mx.array):
+    """MLX-side analogue of _weight_as_2d: (W2d, shape3|None)."""
+    if w.ndim == 2:
+        return w, None
+    if w.ndim == 3:
+        out, k, cin = w.shape
+        return w.transpose(0, 2, 1).reshape(out, cin * k), (out, k, cin)
+    raise LoraError(f"unexpected weight rank {w.ndim} for a LoRA target")
+
+
+def _from2d_mx(w2: mx.array, shape3):
+    if shape3 is None:
+        return w2
+    out, k, cin = shape3
+    return w2.reshape(out, cin, k).transpose(0, 2, 1)
+
+
+def _walk_module(root, path: str):
+    """Resolve 'transformer.layers.3.ff.ff.2' to the live module — integer
+    segments index plain python list containers, names use getattr."""
+    obj = root
+    for part in path.split("."):
+        obj = obj[int(part)] if part.isdigit() else getattr(obj, part)
+    return obj
+
+
+_EVAL_CHUNK = 16  # layers per mx.eval during a transition (26/80 ms per boundary)
+
+
+class LoraStepPlan:
+    """Per-step LoRA gating state for partial-interval adapters.
+
+    Built by :func:`prepare_loras` while the pristine weight dict is available;
+    ``attach(model)`` resolves the live modules after construction; ``sync(i)``
+    (wired as the sampler's ``before_step``) retargets weights in place whenever
+    the active adapter set changes between steps.
+    """
+
+    def __init__(self, num_steps: int, log=lambda _m: None):
+        self.num_steps = num_steps
+        self.log = log
+        self.adapters: list[dict] = []   # {"name","strength","lo","hi"}
+        # npz key → {"parts": {ai: (row|None, col|None, Bp, Ap) mx fp32}}
+        self.layers: dict[str, dict] = {}
+        self.step_sets: tuple = ()
+        self.mods: dict[str, object] = {}
+        self.current: frozenset = frozenset()
+
+    # ── build-time ──────────────────────────────────────────────────────────
+
+    def add_adapter(self, name: str, strength: float, lo: int, hi: int) -> int:
+        self.adapters.append({"name": name, "strength": strength, "lo": lo, "hi": hi})
+        return len(self.adapters) - 1
+
+    def add_layer_part(self, key: str, ai: int, row, col, Bp, Ap) -> None:
+        parts = self.layers.setdefault(key, {"parts": {}})["parts"]
+        parts[ai] = (
+            None if row is None else mx.array(row),
+            None if col is None else mx.array(col),
+            mx.array(Bp), mx.array(Ap),
+        )
+
+    def finalize(self, weights: dict) -> None:
+        """Compute per-step active sets, validate masks, and apply the step-1
+        state to the weight dict (still fp32-safe: results are written back
+        float32; the loader casts to the model dtype)."""
+        self.step_sets = tuple(
+            frozenset(ai for ai, a in enumerate(self.adapters)
+                      if a["lo"] <= i <= a["hi"])
+            for i in range(self.num_steps)
+        )
+        self._validate_masks()
+        n_bound = sum(1 for i in range(1, self.num_steps)
+                      if self.step_sets[i] != self.step_sets[i - 1])
+        init = self.step_sets[0]
+        if init:
+            self._transition_dict(weights, frozenset(), init)
+        self.current = init
+        for ai, a in enumerate(self.adapters):
+            self.log(f"lora: {a['name']} gated to steps {a['lo'] + 1}-{a['hi'] + 1} "
+                     f"(strength {a['strength']:g})")
+        self.log(f"lora: step plan over {len(self.layers)} layer(s), "
+                 f"{n_bound} in-sampler boundary transition(s)")
+
+    def _validate_masks(self) -> None:
+        """Every set that appears must have an invertible mask (|M| bounded away
+        from 0) — checked once in numpy at build time so sync() needs no guard."""
+        for S in set(self.step_sets):
+            for key, info in self.layers.items():
+                m = None
+                for ai in S:
+                    part = info["parts"].get(ai)
+                    if part is None or (part[0] is None and part[1] is None):
+                        continue
+                    row, col, _, _ = part
+                    rv = np.array(row) if row is not None else np.ones(1, np.float32)
+                    cv = np.array(col) if col is not None else np.ones(1, np.float32)
+                    term = self.adapters[ai]["strength"] * (rv[:, None] * cv[None, :] - 1.0)
+                    m = term if m is None else m + term
+                if m is not None and np.abs(1.0 + m).min() < 1e-3:
+                    raise LoraError(
+                        f"{key}: near-singular magnitude mask for step set "
+                        f"{sorted(S)} — this strength/adapter combination cannot "
+                        f"be gated in place (try full-interval merge)")
+
+    # ── transition math ─────────────────────────────────────────────────────
+
+    def _lowrank(self, parts: dict, active: list):
+        facs = [(parts[ai][2], parts[ai][3]) for ai in active]
+        if not facs:
+            return None
+        if len(facs) == 1:
+            return facs[0][0] @ facs[0][1]
+        B = mx.concatenate([f[0] for f in facs], axis=1)
+        A = mx.concatenate([f[1] for f in facs], axis=0)
+        return B @ A
+
+    def _mask(self, parts: dict, active: list):
+        m = None
+        for ai in active:
+            row, col, _, _ = parts[ai]
+            if row is None and col is None:
+                continue
+            rv = row[:, None] if row is not None else 1.0
+            cv = col[None, :] if col is not None else 1.0
+            term = self.adapters[ai]["strength"] * (rv * cv - 1.0)
+            m = term if m is None else m + term
+        return None if m is None else 1.0 + m
+
+    def _retarget(self, w: mx.array, parts: dict, sub: list, add: list,
+                  out_dtype) -> mx.array:
+        w2, shape3 = _as2d_mx(w)
+        x = w2.astype(mx.float32)
+        lr = self._lowrank(parts, sub)
+        if lr is not None:
+            x = x - lr
+        m_s, m_t = self._mask(parts, sub), self._mask(parts, add)
+        if m_s is not None or m_t is not None:
+            x = x * ((m_t if m_t is not None else 1.0) /
+                     (m_s if m_s is not None else 1.0))
+        lr = self._lowrank(parts, add)
+        if lr is not None:
+            x = x + lr
+        if out_dtype is not None:
+            x = x.astype(out_dtype)
+        return _from2d_mx(x, shape3)
+
+    def _transition_dict(self, weights: dict, S: frozenset, T: frozenset) -> None:
+        pending = []
+        for key, info in self.layers.items():
+            sub = sorted(ai for ai in S if ai in info["parts"])
+            add = sorted(ai for ai in T if ai in info["parts"])
+            if sub == add:
+                continue
+            weights[key] = self._retarget(weights[key], info["parts"], sub, add,
+                                          out_dtype=None)
+            pending.append(weights[key])
+            if len(pending) >= _EVAL_CHUNK:
+                mx.eval(pending)
+                pending = []
+        if pending:
+            mx.eval(pending)
+
+    def _transition_model(self, S: frozenset, T: frozenset) -> None:
+        pending = []
+        for key, info in self.layers.items():
+            mod = self.mods[key]
+            sub = sorted(ai for ai in S if ai in info["parts"])
+            add = sorted(ai for ai in T if ai in info["parts"])
+            if sub == add:
+                continue
+            mod.weight = self._retarget(mod.weight, info["parts"], sub, add,
+                                        out_dtype=mod.weight.dtype)
+            pending.append(mod.weight)
+            if len(pending) >= _EVAL_CHUNK:
+                mx.eval(pending)
+                pending = []
+        if pending:
+            mx.eval(pending)
+
+    # ── run-time ────────────────────────────────────────────────────────────
+
+    def attach(self, model) -> None:
+        """Resolve live modules for every managed layer (direct attribute
+        rebinding is a plain python write in mlx.nn.Module — no copy, no GPU
+        work; nothing in this pipeline is mx.compile'd)."""
+        for key in self.layers:
+            path = key[: -len(".weight")] if key.endswith(".weight") else key
+            try:
+                self.mods[key] = _walk_module(model, path)
+            except (AttributeError, IndexError, TypeError) as e:
+                raise LoraError(f"lora step plan: cannot resolve module {path!r} "
+                                f"in the DiT: {e}") from e
+
+    def sync(self, i: int) -> None:
+        """Sampler ``before_step`` hook: make the weights match step i's set."""
+        tgt = self.step_sets[i] if i < self.num_steps else frozenset()
+        if tgt == self.current:
+            return
+        self._transition_model(self.current, tgt)
+        self.current = tgt
+
+
+def prepare_loras(weights: dict, specs: list, num_steps: int,
+                  log=lambda _m: None):
+    """Entry point for the step-gated path. ``specs`` come from
+    :func:`parse_lora_spec`. Full-interval adapters are merged permanently via
+    :func:`merge_loras_into_weights` (bit-identical to the plain --lora path);
+    partial-interval ones become a :class:`LoraStepPlan` whose step-1 state is
+    applied to ``weights`` here. Returns the plan, or None when nothing is
+    step-gated. The seconds-conditioner delta (underfit adapters) cannot be
+    step-gated — conditioning is computed once per generation — so it is left
+    to :func:`apply_conditioner_lora` and excluded from the plan."""
+    full, partial = [], []
+    for s in specs:
+        rs = resolve_steps(s["steps"], num_steps)
+        if rs is None:
+            log(f"lora: {os.path.basename(s['path'])} steps="
+                f"{s['steps']} misses the {num_steps}-step schedule — inactive")
+            continue
+        if rs == (0, num_steps - 1):
+            full.append(s)
+        else:
+            partial.append((s, rs))
+
+    for s in full:
+        stats = merge_loras_into_weights(weights, [s["path"]],
+                                         strength=s["strength"], log=log)
+        log(f"lora: merged {stats['merged']} layer(s) (all steps)")
+
+    if not partial:
+        return None
+
+    plan = LoraStepPlan(num_steps, log=log)
+    for s, (lo, hi) in partial:
+        path = _resolve_path(s["path"])
+        adapter_type, scaling, layers = _parse_adapter(path)
+        ai = plan.add_adapter(os.path.basename(path), s["strength"], lo, hi)
+        skipped = []
+        for layer, params in layers.items():
+            key = _layer_to_npz_key(layer)
+            if key == "cond.seconds_total_weight":
+                log(f"lora: {os.path.basename(path)} conditioner delta applies "
+                    f"to the whole generation (conditioning runs once, before "
+                    f"sampling — steps= does not gate it)")
+                continue
+            if key not in weights:
+                skipped.append(layer)
+                continue
+            need = _PARAMS_FOR.get(adapter_type, ())
+            missing = [n for n in need if n not in params]
+            if missing:
+                raise LoraError(f"{layer}: adapter is {adapter_type} but missing {missing}")
+            W0, _ = _weight_as_2d(weights[key])
+            _check_shapes(layer, W0, params, adapter_type)
+            row, col, Bp, Ap = _delta_form(W0, params, adapter_type, scaling,
+                                           s["strength"])
+            plan.add_layer_part(key, ai, row, col, Bp, Ap)
+        if skipped:
+            log(f"lora: skipped {len(skipped)} layer(s) not in this DiT "
+                f"(e.g. {skipped[0]})")
+    if not plan.layers:
+        log("lora: WARNING — no step-gated layers matched this DiT")
+        return None
+    plan.finalize(weights)
+    return plan
+
+
+def apply_conditioner_lora(W: mx.array, specs: list, log=lambda _m: None):
+    """Apply the seconds-conditioner delta (underfit adapters carry one) to the
+    LIVE conditioner weight — the DiT weight-dict copy of ``cond.*`` is inert
+    because the conditioner is loaded straight from the npz file. Interval-
+    agnostic: conditioning runs once per generation. Returns ``(W_new, n)``
+    with n = number of adapters that contributed."""
+    W0 = np.array(W.astype(mx.float32), dtype=np.float32)
+    acc = None
+    n = 0
+    for s in specs:
+        path = _resolve_path(s["path"])
+        adapter_type, scaling, layers = _parse_adapter(path)
+        params = layers.get(_COND_SECONDS_LAYER)
+        if params is None:
+            continue
+        _check_shapes(_COND_SECONDS_LAYER, W0, params, adapter_type)
+        delta = s["strength"] * (_merged_weight(W0, params, adapter_type, scaling) - W0)
+        acc = delta if acc is None else acc + delta
+        n += 1
+    if acc is None:
+        return W, 0
+    return mx.array(W0 + acc), n

--- a/optimized/mlx/models/defs/lora_merge.py
+++ b/optimized/mlx/models/defs/lora_merge.py
@@ -16,7 +16,10 @@ Two on-disk conventions are supported:
     magnitude_r,magnitude_c}`` with the adapter config
     (``adapter_type``/``rank``/``alpha``/``include``/``exclude``) JSON-encoded in
     the safetensors **metadata** under ``"lora_config"``. Covers all nine adapter
-    types (lora, dora-rows/cols, bora, and the four -xs variants).
+    types (lora, dora-rows/cols, bora, and the four -xs variants). Underfit
+    (github.com/dada-bots/underfit) checkpoints are this convention with
+    full-wrapper layer names (``model.…`` / ``conditioners.…``) — handled by
+    ``_layer_to_npz_key``.
   * **PEFT** (huggingface `peft`): keys ``base_model.model.<layer>.lora_{A,B}.weight``
     with ``r``/``lora_alpha`` in a sibling ``adapter_config.json``. Standard LoRA,
     plus DoRA when ``use_dora`` is set.
@@ -182,10 +185,23 @@ def _mag_2d(mag: np.ndarray, norm_dim: int) -> np.ndarray:
 
 # ── checkpoint parsing → normalized per-layer adapter ──────────────────────────
 
+# Underfit (github.com/dada-bots/underfit) saves adapters with full-wrapper
+# layer names: DiT layers as ``model.transformer...`` and the seconds
+# conditioner Linear as ``conditioners.seconds_total.embedder.embedding.1``.
+# The MLX npz bakes that conditioner Linear as ``cond.seconds_total_weight``.
+_COND_SECONDS_LAYER = "conditioners.seconds_total.embedder.embedding.1"
+
+
 def _layer_to_npz_key(layer: str) -> str:
-    """Map a checkpoint layer name to its DiT npz weight key. The MLX converter
-    renames ``to_local_embed.{0,2}`` → ``to_local_embed.seq.{0,2}`` (dit_mlx.py);
-    every other Linear/Conv1d name passes through unchanged."""
+    """Map a checkpoint layer name to its DiT npz weight key. Strips the
+    full-model ``model.`` prefix (underfit / torch-wrapper checkpoints; bare-DiT
+    names pass through), maps the seconds-conditioner Linear onto its baked npz
+    key, and renames ``to_local_embed.{0,2}`` → ``to_local_embed.seq.{0,2}``
+    (dit_mlx.py); every other Linear/Conv1d name passes through unchanged."""
+    if layer == _COND_SECONDS_LAYER:
+        return "cond.seconds_total_weight"
+    if layer.startswith("model."):
+        layer = layer[len("model."):]
     layer = layer.replace(".to_local_embed.0", ".to_local_embed.seq.0")
     layer = layer.replace(".to_local_embed.2", ".to_local_embed.seq.2")
     return f"{layer}.weight"

--- a/optimized/mlx/models/defs/lora_merge.py
+++ b/optimized/mlx/models/defs/lora_merge.py
@@ -148,10 +148,35 @@ def _merged_weight(W0: np.ndarray, p: dict, adapter_type: str, scaling: float) -
     raise LoraError(f"unknown adapter_type {adapter_type!r}")
 
 
+def _check_shapes(layer: str, W0: np.ndarray, p: dict, adapter_type: str) -> None:
+    """Fail with a clear message when the adapter doesn't fit the base weight —
+    almost always because the adapter was trained for a different base than
+    ``--dit`` (e.g. a medium adapter on sm-music). Without this the mismatch
+    surfaces as a raw numpy broadcasting error deep in the merge."""
+    fan_out, fan_in = W0.shape
+    if adapter_type.endswith("-xs"):
+        rank = p["M_xs"].shape[0]
+        if rank > min(fan_out, fan_in):
+            raise LoraError(
+                f"{layer}: LoRA-XS rank {rank} exceeds base min-dim "
+                f"{min(fan_out, fan_in)} for weight {W0.shape} — wrong base for --dit?"
+            )
+        return
+    b_out, b_rank = p["lora_B"].shape
+    a_rank, a_in = p["lora_A"].shape
+    if b_out != fan_out or a_in != fan_in or a_rank != b_rank:
+        raise LoraError(
+            f"{layer}: adapter lora_B{p['lora_B'].shape}·lora_A{p['lora_A'].shape} "
+            f"does not fit base weight {W0.shape} — wrong base for --dit?"
+        )
+
+
 def _mag_2d(mag: np.ndarray, norm_dim: int) -> np.ndarray:
     """Reshape a (possibly 2D) magnitude vector to broadcast against the weight on
-    ``norm_dim`` (mirrors `magnitude.unsqueeze(norm_dim)` after a squeeze)."""
-    mag = np.squeeze(mag)
+    ``norm_dim`` (mirrors `magnitude.unsqueeze(norm_dim)` after a squeeze).
+    ``atleast_1d`` guards the degenerate (1, 1) case where squeeze yields a
+    0-d array (no real DiT layer has a single output, but keep it total)."""
+    mag = np.atleast_1d(np.squeeze(mag))
     return mag.reshape(-1, 1) if norm_dim == 1 else mag.reshape(1, -1)
 
 
@@ -295,8 +320,9 @@ def merge_loras_into_weights(weights: dict, lora_paths, strength: float = 1.0,
         log(f"lora: {os.path.basename(path)} — {adapter_type}, "
             f"scaling={scaling:.3f}, {len(layers)} target layers")
 
-    # Accumulate deltas per npz key against the *original* weight.
-    deltas: dict[str, np.ndarray] = {}
+    # Accumulate deltas per npz key against the *original* weight. Each entry is
+    # [summed_delta, restore] — the layout restorer is the same across repeats.
+    accum: dict[str, list] = {}
     skipped: list[str] = []
     for path, adapter_type, scaling, layers in parsed:
         need = _PARAMS_FOR.get(adapter_type, ())
@@ -309,25 +335,25 @@ def merge_loras_into_weights(weights: dict, lora_paths, strength: float = 1.0,
             if missing:
                 raise LoraError(f"{layer}: adapter is {adapter_type} but missing {missing}")
             W0, restore = _weight_as_2d(weights[key])
+            _check_shapes(layer, W0, params, adapter_type)
             merged = _merged_weight(W0, params, adapter_type, scaling)
             delta = strength * (merged - W0)
-            deltas[key] = deltas.get(key, 0.0) + delta
-            # stash the layout restorer with the key (same for repeats)
-            deltas.setdefault(key + "\0restore", restore)
+            if key in accum:
+                accum[key][0] += delta
+            else:
+                accum[key] = [delta, restore]
 
-    merged_count = 0
-    for key, delta in list(deltas.items()):
-        if key.endswith("\0restore"):
-            continue
-        restore = deltas[key + "\0restore"]
+    for key, (delta, restore) in accum.items():
         W0, _ = _weight_as_2d(weights[key])
         weights[key] = mx.array(restore(W0 + delta))
-        merged_count += 1
 
     if skipped:
         log(f"lora: skipped {len(skipped)} layer(s) not in this DiT "
             f"(e.g. {skipped[0]})")
-    return {"merged": merged_count, "skipped": skipped, "adapters": len(parsed)}
+    if not accum:
+        log("lora: WARNING — merged 0 layers; the adapter targets nothing in this "
+            "DiT (wrong base for --dit, or unsupported target modules)")
+    return {"merged": len(accum), "skipped": skipped, "adapters": len(parsed)}
 
 
 def _weight_as_2d(arr):

--- a/optimized/mlx/models/defs/lora_merge.py
+++ b/optimized/mlx/models/defs/lora_merge.py
@@ -1,0 +1,349 @@
+"""LoRA merge-at-load for the MLX SA3 DiT.
+
+Adds LoRA inference support to the MLX path, which the `sa3_mlx.py` CLI otherwise
+lacks. The LoRA delta is **merged into the DiT weight dict at load time**, before
+the model is built — no runtime parametrization and no extra per-step forward
+cost. A strength of 0 is a bit-exact bypass.
+
+Trust boundary: only `.safetensors` adapters are accepted. The legacy pickle
+`.ckpt`/`.pt`/`.bin` path — which `torch.load` would execute arbitrary code from —
+is refused outright; this module never calls `torch.load`.
+
+Two on-disk conventions are supported:
+
+  * **SA3-native** (`scripts/train_lora.py` output): tensor keys
+    ``<layer>.parametrizations.weight.0.{lora_A,lora_B,M_xs,magnitude,
+    magnitude_r,magnitude_c}`` with the adapter config
+    (``adapter_type``/``rank``/``alpha``/``include``/``exclude``) JSON-encoded in
+    the safetensors **metadata** under ``"lora_config"``. Covers all nine adapter
+    types (lora, dora-rows/cols, bora, and the four -xs variants).
+  * **PEFT** (huggingface `peft`): keys ``base_model.model.<layer>.lora_{A,B}.weight``
+    with ``r``/``lora_alpha`` in a sibling ``adapter_config.json``. Standard LoRA,
+    plus DoRA when ``use_dora`` is set.
+
+The per-adapter-type math mirrors ``LoRAParametrization.*_forward`` in
+``stable_audio_3/models/lora/model.py`` (and the accumulate-deltas-against-the-
+original-weight semantics of ``merge_loras_into_base_model``), computed in
+float32 and cast back to the DiT dtype. `-xs` adapters do not store their frozen
+SVD bases, so they are recomputed from the base weight here, matching the
+reference (`torch.linalg.svd` + a deterministic sign convention).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import mlx.core as mx
+import numpy as np
+
+# Pickle-backed extensions we refuse to load (the trust boundary).
+_PICKLE_EXTS = (".ckpt", ".pt", ".pth", ".bin")
+
+# Adapter param names per type (mirrors utils._get_adapter_param_names).
+_PARAMS_FOR = {
+    "lora": ("lora_A", "lora_B"),
+    "dora-rows": ("lora_A", "lora_B", "magnitude"),
+    "dora-cols": ("lora_A", "lora_B", "magnitude"),
+    "bora": ("lora_A", "lora_B", "magnitude_r", "magnitude_c"),
+    "lora-xs": ("M_xs",),
+    "dora-rows-xs": ("M_xs", "magnitude"),
+    "dora-cols-xs": ("M_xs", "magnitude"),
+    "bora-xs": ("M_xs", "magnitude_r", "magnitude_c"),
+}
+
+
+class LoraError(Exception):
+    """An adapter could not be loaded or applied."""
+
+
+# ── safetensors reading (no torch, no safetensors pkg — MLX reads it) ──────────
+
+def _np(arr) -> np.ndarray:
+    return np.array(arr.astype(mx.float32), dtype=np.float32)
+
+
+def _load_safetensors(path: str):
+    """Return ``(tensors: dict[str, np.ndarray], metadata: dict)``. Refuses pickle."""
+    lower = path.lower()
+    if lower.endswith(_PICKLE_EXTS):
+        raise LoraError(
+            f"refusing to load pickle-format adapter {os.path.basename(path)!r} — "
+            f"only .safetensors adapters are accepted (a .ckpt/.pt is unpickled by "
+            f"torch.load and can execute arbitrary code)"
+        )
+    if not lower.endswith(".safetensors"):
+        raise LoraError(f"not a .safetensors adapter: {path!r}")
+    arrs, meta = mx.load(path, return_metadata=True)
+    return {k: _np(v) for k, v in arrs.items()}, (meta or {})
+
+
+# ── SVD bases for -xs adapters (recomputed; mirrors model.py) ──────────────────
+
+def _canonicalize_svd_signs(U: np.ndarray, Vh: np.ndarray):
+    """Deterministic sign convention: largest-magnitude element of each U column
+    is positive (mirrors model._canonicalize_svd_signs)."""
+    max_abs_idx = np.argmax(np.abs(U), axis=0)
+    signs = np.sign(U[max_abs_idx, np.arange(U.shape[1])])
+    signs[signs == 0] = 1.0
+    return U * signs[None, :], Vh * signs[:, None]
+
+
+def _svd_bases(W0: np.ndarray, rank: int):
+    """Return ``(U[:, :rank], V[:, :rank])`` from the SVD of ``W0`` (fan_out, fan_in),
+    with V such that ``U @ diag(S) @ V.T`` reconstructs W0 (mirrors model.py)."""
+    U_full, _S, Vh_full = np.linalg.svd(W0, full_matrices=False)
+    U_full, Vh_full = _canonicalize_svd_signs(U_full, Vh_full)
+    U = U_full[:, :rank]
+    V = Vh_full[:rank, :].T
+    return U, V
+
+
+# ── per-type merge math (numpy, float32) ───────────────────────────────────────
+
+def _merged_weight(W0: np.ndarray, p: dict, adapter_type: str, scaling: float) -> np.ndarray:
+    """Return the LoRA-merged weight for one layer at full strength (lora_strength=1).
+
+    ``W0`` is (fan_out, fan_in) float32; ``p`` holds the adapter tensors for this
+    layer. Mirrors the matching ``*_forward`` in model.py.
+    """
+    if adapter_type == "lora":
+        delta = p["lora_B"] @ p["lora_A"]
+        return W0 + scaling * delta
+
+    if adapter_type in ("dora-rows", "dora-cols"):
+        norm_dim = 1 if adapter_type == "dora-rows" else 0
+        delta = p["lora_B"] @ p["lora_A"]
+        V = W0 + scaling * delta
+        V_hat = V / (np.linalg.norm(V, axis=norm_dim, keepdims=True) + 1e-12)
+        mag = _mag_2d(p["magnitude"], norm_dim)
+        return V_hat * mag
+
+    if adapter_type == "bora":
+        delta = p["lora_B"] @ p["lora_A"]
+        V = W0 + scaling * delta
+        V_r = V / (np.linalg.norm(V, axis=1, keepdims=True) + 1e-12)
+        inter = p["magnitude_r"].reshape(-1, 1) * V_r
+        H_c = inter / (np.linalg.norm(inter, axis=0, keepdims=True) + 1e-12)
+        return H_c * p["magnitude_c"].reshape(1, -1)
+
+    if adapter_type.endswith("-xs"):
+        rank = p["M_xs"].shape[0]
+        U, V = _svd_bases(W0, rank)
+        delta = U @ p["M_xs"] @ V.T
+        Vfull = W0 + scaling * delta
+        if adapter_type == "lora-xs":
+            return Vfull
+        if adapter_type in ("dora-rows-xs", "dora-cols-xs"):
+            norm_dim = 1 if adapter_type == "dora-rows-xs" else 0
+            V_hat = Vfull / (np.linalg.norm(Vfull, axis=norm_dim, keepdims=True) + 1e-12)
+            mag = _mag_2d(p["magnitude"], norm_dim)
+            return V_hat * mag
+        if adapter_type == "bora-xs":
+            V_r = Vfull / (np.linalg.norm(Vfull, axis=1, keepdims=True) + 1e-12)
+            inter = p["magnitude_r"].reshape(-1, 1) * V_r
+            H_c = inter / (np.linalg.norm(inter, axis=0, keepdims=True) + 1e-12)
+            return H_c * p["magnitude_c"].reshape(1, -1)
+
+    raise LoraError(f"unknown adapter_type {adapter_type!r}")
+
+
+def _mag_2d(mag: np.ndarray, norm_dim: int) -> np.ndarray:
+    """Reshape a (possibly 2D) magnitude vector to broadcast against the weight on
+    ``norm_dim`` (mirrors `magnitude.unsqueeze(norm_dim)` after a squeeze)."""
+    mag = np.squeeze(mag)
+    return mag.reshape(-1, 1) if norm_dim == 1 else mag.reshape(1, -1)
+
+
+# ── checkpoint parsing → normalized per-layer adapter ──────────────────────────
+
+def _layer_to_npz_key(layer: str) -> str:
+    """Map a checkpoint layer name to its DiT npz weight key. The MLX converter
+    renames ``to_local_embed.{0,2}`` → ``to_local_embed.seq.{0,2}`` (dit_mlx.py);
+    every other Linear/Conv1d name passes through unchanged."""
+    layer = layer.replace(".to_local_embed.0", ".to_local_embed.seq.0")
+    layer = layer.replace(".to_local_embed.2", ".to_local_embed.seq.2")
+    return f"{layer}.weight"
+
+
+def _resolve_path(path: str) -> str:
+    """Accept a .safetensors file or a PEFT adapter directory (resolve to the
+    adapter_model.safetensors inside it)."""
+    if os.path.isdir(path):
+        cand = os.path.join(path, "adapter_model.safetensors")
+        if os.path.isfile(cand):
+            return cand
+        hits = [f for f in os.listdir(path) if f.lower().endswith(".safetensors")]
+        if len(hits) == 1:
+            return os.path.join(path, hits[0])
+        raise LoraError(
+            f"{path!r}: expected one .safetensors adapter in the directory, found {hits}"
+        )
+    return path
+
+
+def _parse_adapter(path: str):
+    """Load one adapter and return ``(adapter_type, scaling, layers)`` where
+    ``layers`` maps a checkpoint layer name → its param dict (numpy float32)."""
+    tensors, meta = _load_safetensors(path)
+
+    native_marker = ".parametrizations.weight.0."
+    is_native = any(native_marker in k for k in tensors)
+
+    if is_native:
+        cfg = json.loads(meta.get("lora_config", "{}")) if meta else {}
+        layers = _group_native(tensors)
+        rank = int(cfg.get("rank") or _infer_rank(layers))
+        alpha = float(cfg.get("alpha", rank))
+        adapter_type = _resolve_native_type(cfg.get("adapter_type", "lora"))
+        scaling = alpha / rank
+        return adapter_type, scaling, layers
+
+    # PEFT — config lives in a sibling adapter_config.json
+    peft_marker = ".lora_A.weight"
+    if any(k.endswith(peft_marker) for k in tensors):
+        cfg = _read_peft_config(path)
+        rank = int(cfg["r"])
+        alpha = float(cfg.get("lora_alpha", rank))
+        use_dora = bool(cfg.get("use_dora", False))
+        use_rslora = bool(cfg.get("use_rslora", False))
+        adapter_type = "dora-rows" if use_dora else "lora"
+        scaling = alpha / (np.sqrt(rank) if use_rslora else rank)
+        layers = _group_peft(tensors)
+        return adapter_type, scaling, layers
+
+    raise LoraError(
+        f"{os.path.basename(path)!r}: not a recognised LoRA (no SA3-native "
+        f"parametrization keys and no PEFT lora_A/lora_B keys)"
+    )
+
+
+def _group_native(tensors: dict) -> dict:
+    marker = ".parametrizations.weight.0."
+    layers: dict[str, dict] = {}
+    for k, v in tensors.items():
+        if marker not in k:
+            continue
+        layer, _, param = k.partition(marker)
+        layers.setdefault(layer, {})[param] = v
+    return layers
+
+
+def _group_peft(tensors: dict) -> dict:
+    prefix = "base_model.model."
+    layers: dict[str, dict] = {}
+    for k, v in tensors.items():
+        name = k[len(prefix):] if k.startswith(prefix) else k
+        for suffix, param in ((".lora_A.weight", "lora_A"),
+                              (".lora_B.weight", "lora_B"),
+                              (".lora_magnitude_vector.weight", "magnitude")):
+            if name.endswith(suffix):
+                layers.setdefault(name[: -len(suffix)], {})[param] = v
+                break
+    return layers
+
+
+def _read_peft_config(path: str) -> dict:
+    base = os.path.dirname(path)
+    cfg_path = os.path.join(base, "adapter_config.json")
+    if not os.path.isfile(cfg_path):
+        raise LoraError(
+            f"PEFT adapter at {path!r} is missing its adapter_config.json sibling"
+        )
+    with open(cfg_path) as fh:
+        return json.load(fh)
+
+
+def _infer_rank(layers: dict) -> int:
+    for params in layers.values():
+        if "lora_A" in params:
+            return params["lora_A"].shape[0]
+        if "M_xs" in params:
+            return params["M_xs"].shape[0]
+    raise LoraError("cannot infer LoRA rank (no lora_A / M_xs tensors)")
+
+
+def _resolve_native_type(adapter_type: str) -> str:
+    """Legacy 'dora' → 'dora-rows' (the paper-correct default; mirrors
+    utils.resolve_adapter_type, minus the 2D-magnitude shape sniff we don't need
+    because saved magnitudes are 1D)."""
+    return "dora-rows" if adapter_type == "dora" else adapter_type
+
+
+# ── public entry point ─────────────────────────────────────────────────────────
+
+def merge_loras_into_weights(weights: dict, lora_paths, strength: float = 1.0,
+                             log=lambda _m: None) -> dict:
+    """Merge one or more LoRA adapters into ``weights`` in place.
+
+    ``weights`` is the DiT weight dict as loaded from the npz (str → mx.array).
+    ``strength`` is the application weight applied to every adapter's delta (the
+    `--lora-strength` knob; matches ``application_weight`` in
+    ``merge_loras_into_base_model``). Deltas are accumulated against the original
+    weight, then applied once, so stacking is order-independent for linear LoRA.
+
+    Returns a stats dict ``{"merged": int, "skipped": list[str], "adapters": int}``.
+    """
+    if not lora_paths:
+        return {"merged": 0, "skipped": [], "adapters": 0}
+
+    parsed = []
+    for raw in lora_paths:
+        path = _resolve_path(raw)
+        adapter_type, scaling, layers = _parse_adapter(path)
+        parsed.append((path, adapter_type, scaling, layers))
+        log(f"lora: {os.path.basename(path)} — {adapter_type}, "
+            f"scaling={scaling:.3f}, {len(layers)} target layers")
+
+    # Accumulate deltas per npz key against the *original* weight.
+    deltas: dict[str, np.ndarray] = {}
+    skipped: list[str] = []
+    for path, adapter_type, scaling, layers in parsed:
+        need = _PARAMS_FOR.get(adapter_type, ())
+        for layer, params in layers.items():
+            key = _layer_to_npz_key(layer)
+            if key not in weights:
+                skipped.append(layer)
+                continue
+            missing = [n for n in need if n not in params]
+            if missing:
+                raise LoraError(f"{layer}: adapter is {adapter_type} but missing {missing}")
+            W0, restore = _weight_as_2d(weights[key])
+            merged = _merged_weight(W0, params, adapter_type, scaling)
+            delta = strength * (merged - W0)
+            deltas[key] = deltas.get(key, 0.0) + delta
+            # stash the layout restorer with the key (same for repeats)
+            deltas.setdefault(key + "\0restore", restore)
+
+    merged_count = 0
+    for key, delta in list(deltas.items()):
+        if key.endswith("\0restore"):
+            continue
+        restore = deltas[key + "\0restore"]
+        W0, _ = _weight_as_2d(weights[key])
+        weights[key] = mx.array(restore(W0 + delta))
+        merged_count += 1
+
+    if skipped:
+        log(f"lora: skipped {len(skipped)} layer(s) not in this DiT "
+            f"(e.g. {skipped[0]})")
+    return {"merged": merged_count, "skipped": skipped, "adapters": len(parsed)}
+
+
+def _weight_as_2d(arr):
+    """Return ``(W2d, restore)`` where ``W2d`` is the PyTorch-layout 2D weight
+    (fan_out, fan_in) as numpy float32, and ``restore(W2d)`` rebuilds the MLX
+    layout. Linear weights are already 2D == PyTorch layout; Conv1d weights are
+    stored MLX-style (out, k, in) and round-trip through PyTorch (out, in, k)."""
+    np_arr = _np(arr)
+    if np_arr.ndim == 2:
+        return np_arr, lambda w: w.astype(np.float32)
+    if np_arr.ndim == 3:
+        out, k, cin = np_arr.shape
+        w2d = np_arr.transpose(0, 2, 1).reshape(out, cin * k)  # (out, in*k), PyTorch order
+
+        def restore(w):
+            return w.reshape(out, cin, k).transpose(0, 2, 1).astype(np.float32)
+
+        return w2d, restore
+    raise LoraError(f"unexpected weight rank {np_arr.ndim} for a LoRA target")

--- a/optimized/mlx/models/defs/lora_merge.py
+++ b/optimized/mlx/models/defs/lora_merge.py
@@ -162,7 +162,7 @@ def _check_shapes(layer: str, W0: np.ndarray, p: dict, adapter_type: str) -> Non
         if rank > min(fan_out, fan_in):
             raise LoraError(
                 f"{layer}: LoRA-XS rank {rank} exceeds base min-dim "
-                f"{min(fan_out, fan_in)} for weight {W0.shape} — wrong base for --dit?"
+                f"{min(fan_out, fan_in)} for weight {W0.shape} — wrong base model?"
             )
         return
     b_out, b_rank = p["lora_B"].shape
@@ -170,7 +170,7 @@ def _check_shapes(layer: str, W0: np.ndarray, p: dict, adapter_type: str) -> Non
     if b_out != fan_out or a_in != fan_in or a_rank != b_rank:
         raise LoraError(
             f"{layer}: adapter lora_B{p['lora_B'].shape}·lora_A{p['lora_A'].shape} "
-            f"does not fit base weight {W0.shape} — wrong base for --dit?"
+            f"does not fit base weight {W0.shape} — wrong base model?"
         )
 
 
@@ -368,7 +368,7 @@ def merge_loras_into_weights(weights: dict, lora_paths, strength: float = 1.0,
             f"(e.g. {skipped[0]})")
     if not accum:
         log("lora: WARNING — merged 0 layers; the adapter targets nothing in this "
-            "DiT (wrong base for --dit, or unsupported target modules)")
+            "DiT (wrong base model, or unsupported target modules)")
     return {"merged": len(accum), "skipped": skipped, "adapters": len(parsed)}
 
 
@@ -712,9 +712,17 @@ class LoraStepPlan:
         self._transition_model(self.current, tgt)
         self.current = tgt
 
+    def clear(self) -> None:
+        """Restore the attached model to its base weights (exact-inverse
+        transition to the empty set). Used by long-lived hosts (gradio) before
+        applying a different adapter configuration to a cached model."""
+        if self.current:
+            self._transition_model(self.current, frozenset())
+            self.current = frozenset()
+
 
 def prepare_loras(weights: dict, specs: list, num_steps: int,
-                  log=lambda _m: None):
+                  log=lambda _m: None, gate_all: bool = False):
     """Entry point for the step-gated path. ``specs`` come from
     :func:`parse_lora_spec`. Full-interval adapters are merged permanently via
     :func:`merge_loras_into_weights` (bit-identical to the plain --lora path);
@@ -722,7 +730,12 @@ def prepare_loras(weights: dict, specs: list, num_steps: int,
     applied to ``weights`` here. Returns the plan, or None when nothing is
     step-gated. The seconds-conditioner delta (underfit adapters) cannot be
     step-gated — conditioning is computed once per generation — so it is left
-    to :func:`apply_conditioner_lora` and excluded from the plan."""
+    to :func:`apply_conditioner_lora` and excluded from the plan.
+
+    gate_all=True routes full-interval adapters through the plan too (they just
+    never transition mid-run). Long-lived hosts use this so plan.clear() can
+    restore the base weights for a cached model — permanent merges can't be
+    undone in place."""
     full, partial = [], []
     for s in specs:
         rs = resolve_steps(s["steps"], num_steps)
@@ -730,7 +743,7 @@ def prepare_loras(weights: dict, specs: list, num_steps: int,
             log(f"lora: {os.path.basename(s['path'])} steps="
                 f"{s['steps']} misses the {num_steps}-step schedule — inactive")
             continue
-        if rs == (0, num_steps - 1):
+        if rs == (0, num_steps - 1) and not gate_all:
             full.append(s)
         else:
             partial.append((s, rs))
@@ -749,9 +762,11 @@ def prepare_loras(weights: dict, specs: list, num_steps: int,
         adapter_type, scaling, layers = _parse_adapter(path)
         ai = plan.add_adapter(os.path.basename(path), s["strength"], lo, hi)
         skipped = []
+        matched = has_cond = 0
         for layer, params in layers.items():
             key = _layer_to_npz_key(layer)
             if key == "cond.seconds_total_weight":
+                has_cond = 1
                 log(f"lora: {os.path.basename(path)} conditioner delta applies "
                     f"to the whole generation (conditioning runs once, before "
                     f"sampling — steps= does not gate it)")
@@ -768,6 +783,12 @@ def prepare_loras(weights: dict, specs: list, num_steps: int,
             row, col, Bp, Ap = _delta_form(W0, params, adapter_type, scaling,
                                            s["strength"])
             plan.add_layer_part(key, ai, row, col, Bp, Ap)
+            matched += 1
+        if not matched and not has_cond:
+            raise LoraError(
+                f"{os.path.basename(path)}: none of this adapter's "
+                f"{len(layers)} layer(s) exist in the target DiT — it was "
+                f"trained for a different base model")
         if skipped:
             log(f"lora: skipped {len(skipped)} layer(s) not in this DiT "
                 f"(e.g. {skipped[0]})")

--- a/optimized/mlx/models/defs/sa3_pipeline.py
+++ b/optimized/mlx/models/defs/sa3_pipeline.py
@@ -102,7 +102,8 @@ def build_pingpong_schedule(steps: int, sigma_max: float = 1.0,
 
 
 def sample_flow_pingpong(model_fn, x: mx.array, sigmas: mx.array, seed: int = 0,
-                         paste_back: tuple | None = None, on_step=None) -> mx.array:
+                         paste_back: tuple | None = None, on_step=None,
+                         before_step=None) -> mx.array:
     """Ping-pong sampler for rf_denoiser models.
 
     Per step i (i = 0 .. num_steps-1):
@@ -111,6 +112,11 @@ def sample_flow_pingpong(model_fn, x: mx.array, sigmas: mx.array, seed: int = 0,
 
     `model_fn(x, t_array)` should return the model's velocity prediction.
     `sigmas` is the schedule of shape (steps+1,) with sigmas[-1] = 0.
+
+    `before_step(i)`, if provided, is called with the 0-based step index right
+    before each model_fn call — used for per-step model state such as LoRA
+    step gating (lora_merge.LoraStepPlan.sync). `on_step(i+1, total)` fires
+    after each step (progress display).
 
     `paste_back`, if provided, is `(init_latents, inpaint_mask)` and instructs
     the sampler to overwrite non-masked positions with the init at the END
@@ -124,6 +130,8 @@ def sample_flow_pingpong(model_fn, x: mx.array, sigmas: mx.array, seed: int = 0,
         t_curr = sigmas[i]
         t_next = sigmas[i + 1]
         t_tensor = t_curr * mx.ones((x.shape[0],), dtype=x.dtype)
+        if before_step is not None:
+            before_step(i)
         v = model_fn(x, t_tensor)
         denoised = x - t_curr.astype(x.dtype) * v
         if i < num_steps - 1 and float(t_next) > 0.0:

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -1030,15 +1030,6 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                     negative_prompt = gr.Textbox(label="Negative prompt", lines=1)
 
                 with gr.Accordion("LoRA", open=False):
-                    gr.Markdown(
-                        "<span style='font-size:0.85em;color:#888'>"
-                        "Adapters (.safetensors — SA3-native / underfit / PEFT), "
-                        "each with its own strength and 1-based inclusive "
-                        "sampling-step range (max slider at the top = last "
-                        "step; skipping step 1 often helps). Adapters must be "
-                        "trained for the selected DiT model. Step-gated "
-                        "adapters are re-merged in place at step boundaries — "
-                        "no reload, no per-step cost.</span>")
                     lora_inputs, lora_rows, lora_rm_btns = [], [], []
                     for _i in range(1, 4):
                         with gr.Group(visible=False) as _grp:

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -27,8 +27,10 @@ Launch:
 from __future__ import annotations
 import argparse
 import base64
+import copy
 import html as html_lib
 import math
+import os
 import re
 import shutil
 import subprocess
@@ -56,6 +58,10 @@ from models.defs.sa3_pipeline import (  # noqa: E402
     apply_prompt_padding, build_pingpong_schedule, sample_flow_pingpong,
     patched_decode, load_conditioner_from_npz,
 )
+from models.defs.lora_merge import (  # noqa: E402
+    prepare_loras, apply_conditioner_lora, LoraError,
+)
+from mlx.utils import tree_flatten  # noqa: E402
 from models.defs.t5gemma_mlx import T5Gemma  # noqa: E402
 from weights import ensure_local  # noqa: E402
 from spec import render_spectrogram_png  # noqa: E402
@@ -167,23 +173,78 @@ def get_conditioner(dit_name: str):
     return _cond_cache[dit_name]
 
 
-def get_dit(dit_name: str, T_lat: int, dtype):
+def _lora_sig(specs, num_steps: int) -> tuple:
+    """Identity of a LoRA config on a cached DiT: file (path+mtime+size —
+    gradio temp uploads keep their path within a session), strength, raw step
+    range, and the schedule length (the plan's step sets depend on it)."""
+    if not specs:
+        return ()
+    sig = []
+    for s in specs:
+        st = os.stat(s["path"])
+        sig.append((s["path"], st.st_mtime_ns, st.st_size,
+                    float(s["strength"]), s["steps"], int(num_steps)))
+    return tuple(sig)
+
+
+def _reconcile_lora(model, dit_name: str, specs, num_steps: int) -> None:
+    """Apply / replace / remove the LoRA config on a cached base DiT, in place.
+
+    A cached model always carries base weights + its current LoraStepPlan
+    state. Changing config = exact-inverse clear back to base, then a fresh
+    plan built from the live module weights (gate_all=True — a permanent merge
+    couldn't be undone in place). One boundary transition each way (~26/80 ms),
+    so tweaking strength or step ranges between generations never reloads the
+    DiT. Same config → no-op (before_step(0) rewinds the plan every run)."""
+    sig = _lora_sig(specs, num_steps)
+    if sig == getattr(model, "_gr_lora_sig", ()):
+        return
+    old = getattr(model, "_lora_plan", None)
+    if old is not None:
+        old.clear()
+    model._lora_plan, model._gr_lora_sig = None, ()
+    if not specs:
+        return
+    wd_view = dict(tree_flatten(model.parameters()))
+    try:
+        plan = prepare_loras(wd_view, specs, num_steps=num_steps,
+                             log=lambda m: print(f"  {m}"), gate_all=True)
+    except LoraError as e:
+        raise LoraError(f"{e} — selected model: {dit_name}") from None
+    if plan is None:
+        return
+    plan.attach(model)
+    # prepare_loras applied the step-1 state to the DICT slots (fp32) — point
+    # the live modules at the new arrays, in the model dtype.
+    swaps = []
+    for lkey, mod in plan.mods.items():
+        if wd_view[lkey] is not mod.weight:
+            mod.weight = wd_view[lkey].astype(mod.weight.dtype)
+            swaps.append(mod.weight)
+    if swaps:
+        mx.eval(swaps)
+    model._lora_plan, model._gr_lora_sig = plan, sig
+
+
+def get_dit(dit_name: str, T_lat: int, dtype, lora_specs=None, num_steps: int = 8):
     key = (dit_name, T_lat)
     if key in _dit_cache:
         if key in _dit_lru:
             _dit_lru.remove(key)
         _dit_lru.append(key)
-        return _dit_cache[key], 0.0
-    while len(_dit_cache) >= _DIT_CACHE_MAX:
-        oldest = _dit_lru.pop(0)
-        print(f"  ← LRU-evicting DiT {oldest}")
-        _dit_cache.pop(oldest, None)
-        _free_to_pool()
-    t0 = time.time()
-    model, _ = load_dit(dit_name, T_lat=T_lat, dtype=dtype)
-    load_ms = (time.time() - t0) * 1000
-    _dit_cache[key] = model
-    _dit_lru.append(key)
+        model, load_ms = _dit_cache[key], 0.0
+    else:
+        while len(_dit_cache) >= _DIT_CACHE_MAX:
+            oldest = _dit_lru.pop(0)
+            print(f"  ← LRU-evicting DiT {oldest}")
+            _dit_cache.pop(oldest, None)
+            _free_to_pool()
+        t0 = time.time()
+        model, _ = load_dit(dit_name, T_lat=T_lat, dtype=dtype)
+        load_ms = (time.time() - t0) * 1000
+        _dit_cache[key] = model
+        _dit_lru.append(key)
+    _reconcile_lora(model, dit_name, lora_specs, num_steps)
     return model, load_ms
 
 
@@ -205,7 +266,8 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
                    seed: int, cfg: float, apg: float, sigma_max: float,
                    a2a_audio_path: str | None = None,
                    inpaint_audio_path: str | None = None,
-                   inpaint_range_sec=None):
+                   inpaint_range_sec=None,
+                   lora_specs=None):
     """Returns (audio_np (2,T) float32, timings dict).
 
     a2a and inpainting are independent and combinable:
@@ -230,6 +292,14 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
     # 2. Conditioning
     t0 = time.time()
     padding_emb, secs_embedder = get_conditioner(dit_name)
+    if lora_specs:
+        # Seconds-conditioner deltas (underfit adapters carry one) apply to the
+        # whole generation — conditioning runs once, before sampling. Work on a
+        # copy so the cached embedder stays pristine.
+        W_lora, _n_cond = apply_conditioner_lora(secs_embedder.W, lora_specs)
+        if _n_cond:
+            secs_embedder = copy.copy(secs_embedder)
+            secs_embedder.W = W_lora
     embeds = embeds.astype(dtype)
     embeds_padded = apply_prompt_padding(embeds, mask, padding_emb.astype(dtype))
     seconds_embed = secs_embedder(seconds).astype(dtype)
@@ -289,7 +359,8 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
         t["enc_ms"] += (time.time() - t0) * 1000
 
     # 3b. DiT + pingpong sample
-    dit_model, t["dit_load_ms"] = get_dit(dit_name, T_lat, dtype)
+    dit_model, t["dit_load_ms"] = get_dit(dit_name, T_lat, dtype,
+                                          lora_specs=lora_specs, num_steps=steps)
     sigmas = build_pingpong_schedule(steps, sigma_max=sigma_max, use_logsnr_shift=True)
 
     key = mx.random.key(seed)
@@ -346,8 +417,10 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
         return cfg_v.astype(x.dtype)
 
     t0 = time.time()
+    _plan = getattr(dit_model, "_lora_plan", None)
     latents = sample_flow_pingpong(model_fn, noise, sigmas, seed=seed + 1,
-                                   paste_back=paste_back)
+                                   paste_back=paste_back,
+                                   before_step=_plan.sync if _plan else None)
     mx.eval(latents)
     t["sample_ms"] = (time.time() - t0) * 1000
 
@@ -485,6 +558,48 @@ def _ago(ts) -> str:
     return f"{int(d // 86400)}d ago"
 
 
+def _lora_specs_from_ui(vals, notes):
+    """Turn the 3 LoRA rows' flat values (file, strength, min, max)×3 into
+    lora_merge specs. Empty rows are skipped; half-sane inputs get a note and
+    the most permissive interpretation (never an error — matches the app's
+    permissive-by-design generation policy)."""
+    specs = []
+    for i in range(3):
+        path, strength, mn, mxx = vals[4 * i: 4 * i + 4]
+        if not path:
+            continue
+        mn = int(mn) if mn else None
+        mxx = int(mxx) if mxx else None
+        if mn is not None and mn < 1:
+            mn = 1
+        if mxx is not None and mxx < 1:
+            notes.append(f"LoRA {i + 1}: max step < 1 — treated as 'last step'")
+            mxx = None
+        if mn is not None and mxx is not None and mn > mxx:
+            notes.append(f"LoRA {i + 1}: min step {mn} > max step {mxx} — adapter skipped")
+            continue
+        steps = None if ((mn is None or mn == 1) and mxx is None) else (mn, mxx)
+        specs.append({"path": path, "strength": float(strength), "steps": steps})
+    return specs or None
+
+
+def _lora_disp(specs) -> str:
+    """Short human tag per adapter: 'plini×0.8 @2-8, rain @1-4'."""
+    tags = []
+    for s in specs or []:
+        name = Path(s["path"]).stem
+        if len(name) > 25:
+            name = name[:24] + "…"
+        tag = name
+        if s["strength"] != 1.0:
+            tag += f"×{s['strength']:g}"
+        if s["steps"]:
+            lo, hi = s["steps"]
+            tag += f" @{lo or 1}-{hi if hi is not None else 'end'}"
+        tags.append(tag)
+    return ", ".join(tags)
+
+
 def _meta_suffix(entry) -> str:
     """' · cfg 1.5 · noise 0.92 · audio2audio · inpainting' — only the non-defaults.
     The sigma tag reads 'noise' for a2a runs (it IS the init_noise_level there),
@@ -505,6 +620,8 @@ def _meta_suffix(entry) -> str:
         parts.append("audio2audio")
     if "inpaint" in mode:
         parts.append("inpainting")
+    if entry.get("lora"):
+        parts.append(f"lora {entry['lora']}")
     return "".join(f" · {p}" for p in parts)
 
 
@@ -651,13 +768,14 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
     def _generate_entry(dit_name, decoder_name, prompt, negative_prompt,
                         seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
                         a2a_audio, inpaint_audio, inp_start, inp_end,
-                        output_opts, file_format):
+                        output_opts, file_format, *lora_vals):
         """Run one generation and package it as a history entry.
         Returns (entry, None) or (None, error_message)."""
         prompt = (prompt or "").strip()
         # Permissive by design: a generation should succeed with whatever IS set.
         # Half-configured features are ignored with a visible note, never an error.
         notes = []
+        lora_specs = _lora_specs_from_ui(lora_vals, notes) if lora_vals else None
         # blank or -1 → random seed, kept small (1-9999) for readability
         try:
             seed = int(seed_text.strip()) if seed_text and seed_text.strip() else -1
@@ -705,7 +823,9 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 dit_name, decoder_name, prompt, negative_prompt or "",
                 float(seconds), int(steps), seed, float(cfg), float(apg),
                 float(sigma_max), a2a_audio or None, inpaint_audio or None,
-                inpaint_range)
+                inpaint_range, lora_specs)
+        except LoraError as e:
+            return None, f"LoRA error: {e}"
         except Exception as e:
             return None, f"error: {type(e).__name__}: {e}"
         if not np.isfinite(audio_np).all():
@@ -741,12 +861,14 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         enc_note = f"encode {t['enc_ms']:.0f} ms{cached_tag} ·&nbsp; " if t.get("enc_ms") else ""
         apg_note = f" (apg {apg:g})" if apg != 1.0 else ""
         cfg_note = f"cfg {cfg:g}{apg_note} ·&nbsp; " if cfg != 1.0 else ""
+        lora_note = (f"<b>lora</b>: {html_lib.escape(_lora_disp(lora_specs))} ·&nbsp; "
+                     if lora_specs else "")
         prompt_disp = html_lib.escape(prompt) or "<i>(no prompt)</i>"
         neg_disp = (f' · <span style="opacity:0.75">neg: {html_lib.escape(negative_prompt.strip())}</span>'
                     if negative_prompt and negative_prompt.strip() and cfg != 1.0 else "")
         timing_html = (
             f"{prompt_disp}{neg_disp} ·&nbsp; "
-            f"{load_note}{enc_note}{cfg_note}"
+            f"{load_note}{enc_note}{cfg_note}{lora_note}"
             f"<b>Inference</b>: {t['inference_ms']:.0f} ms "
             f"<span style='color:#888'>(t5={t['t5_ms']:.0f} · sample={t['sample_ms']:.0f} · "
             f"decode={t['decode_ms']:.0f})</span> ·&nbsp; "
@@ -772,6 +894,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             "mode": mode,
             "prompt": prompt,
             "seed": seed,
+            "lora": _lora_disp(lora_specs),
             "spec_b64": spec_b64,
             "timing": timing_html,
         }
@@ -797,11 +920,13 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
     def generate(dit_name, decoder_name, prompt, negative_prompt,
                  seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
                  a2a_audio, inpaint_audio, inp_start, inp_end,
-                 output_opts, file_format, state):
+                 output_opts, file_format, *lora_and_state):
+        *lora_vals, state = lora_and_state
         entry, err_msg = _generate_entry(
             dit_name, decoder_name, prompt, negative_prompt, seconds, steps,
             seed_text, cfg, apg, sigma_max, init_noise, a2a_audio,
-            inpaint_audio, inp_start, inp_end, output_opts, file_format)
+            inpaint_audio, inp_start, inp_end, output_opts, file_format,
+            *lora_vals)
         if entry is None:
             return (gr.update(), gr.update(),
                     f"<span style='color:#f88'>{err_msg}</span>",
@@ -816,17 +941,19 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
     def promote(dit_name, decoder_name, prompt, negative_prompt,
                 seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
                 a2a_audio, inpaint_audio, inp_start, inp_end,
-                output_opts, file_format, state):
+                output_opts, file_format, *lora_and_state):
         """Infinite Radio: swap the pre-generated clip in when playback ends.
         Falls back to a full generate if the queue is empty. Either way the
         next track ALWAYS autoplays — Auto-play only governs whether a clip
         starts when nothing was playing; radio transitions are continuations."""
+        *lora_vals, state = lora_and_state
         q = state.get("queued")
         if q is None:
             entry, err_msg = _generate_entry(
                 dit_name, decoder_name, prompt, negative_prompt, seconds, steps,
                 seed_text, cfg, apg, sigma_max, init_noise, a2a_audio,
-                inpaint_audio, inp_start, inp_end, output_opts, file_format)
+                inpaint_audio, inp_start, inp_end, output_opts, file_format,
+                *lora_vals)
             if entry is None:
                 return (gr.update(), gr.update(),
                         f"<span style='color:#f88'>{err_msg}</span>",
@@ -839,16 +966,18 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
     def pregen(dit_name, decoder_name, prompt, negative_prompt,
                seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
                a2a_audio, inpaint_audio, inp_start, inp_end,
-               output_opts, file_format, state):
+               output_opts, file_format, *lora_and_state):
         """Chained after generate/promote: pre-generate the NEXT clip while the
         current one plays (Infinite Radio only)."""
+        *lora_vals, state = lora_and_state
         if "Infinite Radio" not in (output_opts or []):
             state["queued"] = None
             return "", state
         entry, err_msg = _generate_entry(
             dit_name, decoder_name, prompt, negative_prompt, seconds, steps,
             seed_text, cfg, apg, sigma_max, init_noise, a2a_audio,
-            inpaint_audio, inp_start, inp_end, output_opts, file_format)
+            inpaint_audio, inp_start, inp_end, output_opts, file_format,
+            *lora_vals)
         if entry is None:
             return (f"<div style='color:#f88; font-size:0.85em'>queue: {err_msg}</div>",
                     state)
@@ -898,6 +1027,33 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                         sigma_global = gr.Slider(label="sigma_max",
                                                  minimum=0.0, maximum=1.0, value=1.0, step=0.01)
                     negative_prompt = gr.Textbox(label="Negative prompt", lines=1)
+
+                with gr.Accordion("LoRA", open=False):
+                    gr.Markdown(
+                        "<span style='font-size:0.85em;color:#888'>"
+                        "Up to 3 adapters (.safetensors — SA3-native / underfit / "
+                        "PEFT), each with its own strength and 1-based inclusive "
+                        "sampling-step range (blank max = last step; skipping "
+                        "step 1 often helps). Adapters must be trained for the "
+                        "selected DiT model. Step-gated adapters are re-merged "
+                        "in place at step boundaries — no reload, no per-step "
+                        "cost.</span>")
+                    lora_inputs = []
+                    for _i in range(1, 4):
+                        with gr.Row():
+                            _lf = gr.File(label=f"LoRA {_i} (.safetensors)",
+                                          file_types=[".safetensors"],
+                                          type="filepath", scale=3, height=88)
+                            _ls = gr.Slider(label="Strength", minimum=0.0,
+                                            maximum=2.0, value=1.0, step=0.05,
+                                            scale=2)
+                            _ln = gr.Number(label="Min step", value=1,
+                                            precision=0, minimum=1, scale=1,
+                                            min_width=80)
+                            _lx = gr.Number(label="Max step (blank = last)",
+                                            value=None, precision=0, minimum=1,
+                                            scale=1, min_width=80)
+                        lora_inputs += [_lf, _ls, _ln, _lx]
 
                 with gr.Accordion("Audio-to-audio (guide the whole clip)", open=False):
                     a2a_audio = gr.Audio(label="Guide audio — generation starts from its latents",
@@ -959,7 +1115,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         ctrl_inputs = [dit_dd, decoder_dd, prompt, negative_prompt,
                        seconds, steps, seed, cfg, apg, sigma_global,
                        sigma_slider, a2a_audio, inpaint_audio,
-                       inp_start, inp_end, output_opts, file_format]
+                       inp_start, inp_end, output_opts, file_format] + lora_inputs
         main_outputs = [output_player, timing, error_box, queued_html, history_html, st]
 
         # NB: _present returns (player, timing, err, history, queued, state) —

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -1039,26 +1039,25 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                         "trained for the selected DiT model. Step-gated "
                         "adapters are re-merged in place at step boundaries — "
                         "no reload, no per-step cost.</span>")
-                    lora_inputs, lora_groups, lora_rm_btns = [], [], []
+                    lora_inputs, lora_rows, lora_rm_btns = [], [], []
                     for _i in range(1, 4):
-                        with gr.Group(visible=False) as _grp:
-                            with gr.Row():
-                                _lf = gr.File(label=f"LoRA {_i} (.safetensors)",
-                                              file_types=[".safetensors"],
-                                              type="filepath", scale=4, height=88)
-                                _ls = gr.Slider(label="strength", minimum=0.0,
-                                                maximum=10.0, value=1.0, step=0.1,
-                                                scale=3)
-                                _rm = gr.Button("✕ remove", size="sm", scale=0,
-                                                min_width=90)
-                            with gr.Row():
-                                _ln = gr.Slider(label="Min step", minimum=1,
-                                                maximum=default_steps, value=1,
-                                                step=1)
-                                _lx = gr.Slider(label="Max step", minimum=1,
-                                                maximum=default_steps,
-                                                value=default_steps, step=1)
-                        lora_groups.append(_grp)
+                        with gr.Row(visible=False, equal_height=True) as _row:
+                            _lf = gr.File(label=f"LoRA {_i} (.safetensors)",
+                                          file_types=[".safetensors"],
+                                          type="filepath", scale=3, height=88)
+                            _ls = gr.Slider(label="strength", minimum=0.0,
+                                            maximum=10.0, value=1.0, step=0.1,
+                                            scale=2, min_width=110)
+                            _ln = gr.Slider(label="Min step", minimum=1,
+                                            maximum=default_steps, value=1,
+                                            step=1, scale=1, min_width=80)
+                            _lx = gr.Slider(label="Max step", minimum=1,
+                                            maximum=default_steps,
+                                            value=default_steps, step=1,
+                                            scale=1, min_width=80)
+                            _rm = gr.Button("✕", size="sm", scale=0,
+                                            min_width=36)
+                        lora_rows.append(_row)
                         lora_rm_btns.append(_rm)
                         lora_inputs += [_lf, _ls, _ln, _lx]
                     lora_add_btn = gr.Button("+ Add LoRA", size="sm")
@@ -1131,7 +1130,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             return ([gr.update(visible=v) for v in vis]
                     + [gr.update(visible=not all(vis)), vis])
         lora_add_btn.click(lora_add, inputs=[lora_vis],
-                           outputs=lora_groups + [lora_add_btn, lora_vis])
+                           outputs=lora_rows + [lora_add_btn, lora_vis])
 
         def _lora_remove(idx):
             def _rm(vis, cur_steps):
@@ -1144,7 +1143,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             return _rm
         for _idx, _btn in enumerate(lora_rm_btns):
             _btn.click(_lora_remove(_idx), inputs=[lora_vis, steps],
-                       outputs=lora_groups + [lora_add_btn, lora_vis]
+                       outputs=lora_rows + [lora_add_btn, lora_vis]
                        + lora_inputs[4 * _idx: 4 * _idx + 4])
 
         def on_steps_change(s):

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -1041,23 +1041,25 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                         "no reload, no per-step cost.</span>")
                     lora_inputs, lora_rows, lora_rm_btns = [], [], []
                     for _i in range(1, 4):
-                        with gr.Row(visible=False, equal_height=True) as _row:
-                            _lf = gr.File(label=f"LoRA {_i} (.safetensors)",
-                                          file_types=[".safetensors"],
-                                          type="filepath", scale=3, height=88)
-                            _ls = gr.Slider(label="strength", minimum=0.0,
-                                            maximum=10.0, value=1.0, step=0.1,
-                                            scale=2, min_width=110)
-                            _ln = gr.Slider(label="Min step", minimum=1,
-                                            maximum=default_steps, value=1,
-                                            step=1, scale=1, min_width=80)
-                            _lx = gr.Slider(label="Max step", minimum=1,
-                                            maximum=default_steps,
-                                            value=default_steps, step=1,
-                                            scale=1, min_width=80)
-                            _rm = gr.Button("✕", size="sm", scale=0,
-                                            min_width=36)
-                        lora_rows.append(_row)
+                        with gr.Group(visible=False) as _grp:
+                            with gr.Row(equal_height=True):
+                                _lf = gr.File(label=f"LoRA {_i} (.safetensors)",
+                                              file_types=[".safetensors"],
+                                              type="filepath", scale=1, height=88)
+                                _rm = gr.Button("✕", size="sm", scale=0,
+                                                min_width=36)
+                            with gr.Row():
+                                _ls = gr.Slider(label="strength", minimum=0.0,
+                                                maximum=10.0, value=1.0, step=0.1,
+                                                scale=2, min_width=110)
+                                _ln = gr.Slider(label="Min step", minimum=1,
+                                                maximum=default_steps, value=1,
+                                                step=1, scale=1, min_width=80)
+                                _lx = gr.Slider(label="Max step", minimum=1,
+                                                maximum=default_steps,
+                                                value=default_steps, step=1,
+                                                scale=1, min_width=80)
+                        lora_rows.append(_grp)
                         lora_rm_btns.append(_rm)
                         lora_inputs += [_lf, _ls, _ln, _lx]
                     lora_add_btn = gr.Button("+ Add LoRA", size="sm")

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -558,27 +558,27 @@ def _ago(ts) -> str:
     return f"{int(d // 86400)}d ago"
 
 
-def _lora_specs_from_ui(vals, notes):
+def _lora_specs_from_ui(vals, notes, num_steps):
     """Turn the 3 LoRA rows' flat values (file, strength, min, max)×3 into
-    lora_merge specs. Empty rows are skipped; half-sane inputs get a note and
-    the most permissive interpretation (never an error — matches the app's
-    permissive-by-design generation policy)."""
+    lora_merge specs. Empty rows are skipped; a min slider at 1 / max slider at
+    (or beyond) the schedule length mean 'from the start' / 'to the last step',
+    so a maxed-out range slider keeps meaning 'all steps' when Steps changes.
+    Half-sane inputs get a note and the most permissive interpretation (never
+    an error — matches the app's permissive-by-design generation policy)."""
     specs = []
     for i in range(3):
         path, strength, mn, mxx = vals[4 * i: 4 * i + 4]
         if not path:
             continue
-        mn = int(mn) if mn else None
-        mxx = int(mxx) if mxx else None
-        if mn is not None and mn < 1:
-            mn = 1
-        if mxx is not None and mxx < 1:
-            notes.append(f"LoRA {i + 1}: max step < 1 — treated as 'last step'")
-            mxx = None
+        mn = int(mn) if mn and int(mn) > 1 else None
+        mxx = int(mxx) if mxx and int(mxx) < num_steps else None
+        if mn is not None and mn > num_steps:
+            notes.append(f"LoRA {i + 1}: min step {mn} is beyond the "
+                         f"{num_steps}-step schedule — adapter inactive")
         if mn is not None and mxx is not None and mn > mxx:
             notes.append(f"LoRA {i + 1}: min step {mn} > max step {mxx} — adapter skipped")
             continue
-        steps = None if ((mn is None or mn == 1) and mxx is None) else (mn, mxx)
+        steps = None if (mn is None and mxx is None) else (mn, mxx)
         specs.append({"path": path, "strength": float(strength), "steps": steps})
     return specs or None
 
@@ -775,7 +775,8 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         # Permissive by design: a generation should succeed with whatever IS set.
         # Half-configured features are ignored with a visible note, never an error.
         notes = []
-        lora_specs = _lora_specs_from_ui(lora_vals, notes) if lora_vals else None
+        lora_specs = (_lora_specs_from_ui(lora_vals, notes, int(steps))
+                      if lora_vals else None)
         # blank or -1 → random seed, kept small (1-9999) for readability
         try:
             seed = int(seed_text.strip()) if seed_text and seed_text.strip() else -1
@@ -1031,29 +1032,37 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
                 with gr.Accordion("LoRA", open=False):
                     gr.Markdown(
                         "<span style='font-size:0.85em;color:#888'>"
-                        "Up to 3 adapters (.safetensors — SA3-native / underfit / "
-                        "PEFT), each with its own strength and 1-based inclusive "
-                        "sampling-step range (blank max = last step; skipping "
-                        "step 1 often helps). Adapters must be trained for the "
-                        "selected DiT model. Step-gated adapters are re-merged "
-                        "in place at step boundaries — no reload, no per-step "
-                        "cost.</span>")
-                    lora_inputs = []
+                        "Adapters (.safetensors — SA3-native / underfit / PEFT), "
+                        "each with its own strength and 1-based inclusive "
+                        "sampling-step range (max slider at the top = last "
+                        "step; skipping step 1 often helps). Adapters must be "
+                        "trained for the selected DiT model. Step-gated "
+                        "adapters are re-merged in place at step boundaries — "
+                        "no reload, no per-step cost.</span>")
+                    lora_inputs, lora_groups, lora_rm_btns = [], [], []
                     for _i in range(1, 4):
-                        with gr.Row():
-                            _lf = gr.File(label=f"LoRA {_i} (.safetensors)",
-                                          file_types=[".safetensors"],
-                                          type="filepath", scale=3, height=88)
-                            _ls = gr.Slider(label="Strength", minimum=0.0,
-                                            maximum=2.0, value=1.0, step=0.05,
-                                            scale=2)
-                            _ln = gr.Number(label="Min step", value=1,
-                                            precision=0, minimum=1, scale=1,
-                                            min_width=80)
-                            _lx = gr.Number(label="Max step (blank = last)",
-                                            value=None, precision=0, minimum=1,
-                                            scale=1, min_width=80)
+                        with gr.Group(visible=False) as _grp:
+                            with gr.Row():
+                                _lf = gr.File(label=f"LoRA {_i} (.safetensors)",
+                                              file_types=[".safetensors"],
+                                              type="filepath", scale=4, height=88)
+                                _ls = gr.Slider(label="strength", minimum=0.0,
+                                                maximum=10.0, value=1.0, step=0.1,
+                                                scale=3)
+                                _rm = gr.Button("✕ remove", size="sm", scale=0,
+                                                min_width=90)
+                            with gr.Row():
+                                _ln = gr.Slider(label="Min step", minimum=1,
+                                                maximum=default_steps, value=1,
+                                                step=1)
+                                _lx = gr.Slider(label="Max step", minimum=1,
+                                                maximum=default_steps,
+                                                value=default_steps, step=1)
+                        lora_groups.append(_grp)
+                        lora_rm_btns.append(_rm)
                         lora_inputs += [_lf, _ls, _ln, _lx]
+                    lora_add_btn = gr.Button("+ Add LoRA", size="sm")
+                    lora_vis = gr.State([False, False, False])
 
                 with gr.Accordion("Audio-to-audio (guide the whole clip)", open=False):
                     a2a_audio = gr.Audio(label="Guide audio — generation starts from its latents",
@@ -1111,6 +1120,39 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
             return gr.update(), opts
         output_opts.change(on_opts_change, inputs=[output_opts, opts_state],
                            outputs=[output_opts, opts_state])
+
+        def lora_add(vis):
+            """Reveal the first hidden LoRA row; hide the button at 3/3."""
+            vis = list(vis)
+            for i, v in enumerate(vis):
+                if not v:
+                    vis[i] = True
+                    break
+            return ([gr.update(visible=v) for v in vis]
+                    + [gr.update(visible=not all(vis)), vis])
+        lora_add_btn.click(lora_add, inputs=[lora_vis],
+                           outputs=lora_groups + [lora_add_btn, lora_vis])
+
+        def _lora_remove(idx):
+            def _rm(vis, cur_steps):
+                vis = list(vis)
+                vis[idx] = False
+                return ([gr.update(visible=v) for v in vis]
+                        + [gr.update(visible=True), vis,
+                           None, 1.0, 1, int(cur_steps)])  # reset the row
+            _rm.__name__ = f"lora_remove_{idx + 1}"
+            return _rm
+        for _idx, _btn in enumerate(lora_rm_btns):
+            _btn.click(_lora_remove(_idx), inputs=[lora_vis, steps],
+                       outputs=lora_groups + [lora_add_btn, lora_vis]
+                       + lora_inputs[4 * _idx: 4 * _idx + 4])
+
+        def on_steps_change(s):
+            # keep the 6 step-range sliders bounded by the schedule length
+            return [gr.update(maximum=int(s))] * 6
+        steps.change(on_steps_change, inputs=[steps],
+                     outputs=[c for i in range(3)
+                              for c in lora_inputs[4 * i + 2: 4 * i + 4]])
 
         ctrl_inputs = [dit_dd, decoder_dd, prompt, negative_prompt,
                        seconds, steps, seed, cfg, apg, sigma_global,

--- a/optimized/mlx/scripts/sa3_mlx.py
+++ b/optimized/mlx/scripts/sa3_mlx.py
@@ -170,13 +170,18 @@ def prompt_user_if_missing(args):
     return args
 
 
-def load_dit(dit_name: str, T_lat: int, dtype):
+def load_dit(dit_name: str, T_lat: int, dtype, lora_paths=None, lora_strength=1.0):
     cfg = DIT_CHOICES[dit_name]
     ckpt = ensure_local(cfg["ckpt"])
     import importlib, io, contextlib
     mod = importlib.import_module(cfg["loader"])
+    # The loader's own chatter is swallowed, but the LoRA merge summary is routed
+    # to stderr (not redirected) so it stays visible to callers that capture it.
+    lora_log = lambda m: print(m, file=sys.stderr)
     with contextlib.redirect_stdout(io.StringIO()):
-        model = mod.load_dit(str(ckpt), T_lat=T_lat, dtype=dtype, compile_=False)
+        model = mod.load_dit(str(ckpt), T_lat=T_lat, dtype=dtype, compile_=False,
+                             lora_paths=lora_paths, lora_strength=lora_strength,
+                             lora_log=lora_log)
     return model, str(ckpt)
 
 
@@ -387,6 +392,16 @@ def main():
                     help="Path to the bundled T5Gemma FP16 .npz (weights + tokenizer). "
                          "Default points at models/mlx/t5gemma_f16.npz next to this script; "
                          "auto-downloaded from HuggingFace if not present.")
+    ap.add_argument("--lora", nargs="+", default=None, metavar="ADAPTER",
+                    help="One or more LoRA adapters to merge into the DiT at load time. "
+                         "Each is a .safetensors file (SA3-native train_lora.py output) or a "
+                         "PEFT adapter directory/.safetensors (with its adapter_config.json). "
+                         "ONLY .safetensors is accepted — a pickle .ckpt/.pt is refused (it "
+                         "would execute code on load). The adapter's base must match --dit "
+                         "(e.g. a medium adapter with --dit medium).")
+    ap.add_argument("--lora-strength", type=float, default=1.0,
+                    help="Application weight for every --lora delta (default 1.0). 0 disables "
+                         "the adapter (bit-identical to no LoRA); >1 amplifies it.")
 
     # ── Sampling ──────────────────────────────────────────────────────────────
     ap.add_argument("--seconds", type=float, default=30.0,
@@ -638,7 +653,11 @@ def main():
 
     # ── 3b. DiT pingpong sampling ──
     stage("[3/5]", f"DiT — load + sample ({args.steps} steps, σmax={sigma_max:.2f})")
-    t0 = time.time(); dit_model, _ = load_dit(args.dit, T_lat=T_lat, dtype=dtype)
+    if args.lora:
+        sub(f"lora  {', '.join(os.path.basename(p.rstrip('/')) for p in args.lora)}  "
+            f"(strength {args.lora_strength:g})")
+    t0 = time.time(); dit_model, _ = load_dit(args.dit, T_lat=T_lat, dtype=dtype,
+                                              lora_paths=args.lora, lora_strength=args.lora_strength)
     _stage_peak_b('DiT load')
     sub(f"load {time.time()-t0:.1f}s")
 

--- a/optimized/mlx/scripts/sa3_mlx.py
+++ b/optimized/mlx/scripts/sa3_mlx.py
@@ -170,7 +170,7 @@ def prompt_user_if_missing(args):
     return args
 
 
-def load_dit(dit_name: str, T_lat: int, dtype, lora_paths=None, lora_strength=1.0):
+def load_dit(dit_name: str, T_lat: int, dtype, lora_specs=None, num_steps=None):
     cfg = DIT_CHOICES[dit_name]
     ckpt = ensure_local(cfg["ckpt"])
     import importlib, io, contextlib
@@ -180,7 +180,7 @@ def load_dit(dit_name: str, T_lat: int, dtype, lora_paths=None, lora_strength=1.
     lora_log = lambda m: print(m, file=sys.stderr)
     with contextlib.redirect_stdout(io.StringIO()):
         model = mod.load_dit(str(ckpt), T_lat=T_lat, dtype=dtype, compile_=False,
-                             lora_paths=lora_paths, lora_strength=lora_strength,
+                             lora_specs=lora_specs, num_steps=num_steps,
                              lora_log=lora_log)
     return model, str(ckpt)
 
@@ -392,16 +392,24 @@ def main():
                     help="Path to the bundled T5Gemma FP16 .npz (weights + tokenizer). "
                          "Default points at models/mlx/t5gemma_f16.npz next to this script; "
                          "auto-downloaded from HuggingFace if not present.")
-    ap.add_argument("--lora", nargs="+", default=None, metavar="ADAPTER",
-                    help="One or more LoRA adapters to merge into the DiT at load time. "
-                         "Each is a .safetensors file (SA3-native train_lora.py output) or a "
-                         "PEFT adapter directory/.safetensors (with its adapter_config.json). "
-                         "ONLY .safetensors is accepted — a pickle .ckpt/.pt is refused (it "
-                         "would execute code on load). The adapter's base must match --dit "
-                         "(e.g. a medium adapter with --dit medium).")
+    ap.add_argument("--lora", action="append", nargs="+", default=None,
+                    metavar=("ADAPTER", "KEY=VAL"),
+                    help="A LoRA adapter to apply to the DiT — repeat the flag for several. "
+                         "Each --lora takes the adapter path followed by optional key=value "
+                         "options: strength=S (default --lora-strength) and steps=RANGE, a "
+                         "1-based inclusive sampling-step range: 2-8, 2- (2..last), -4 (1..4) "
+                         "or 3 (just step 3; default: all steps). Example: "
+                         "--lora plini.safetensors strength=0.8 steps=2- . Adapters covering "
+                         "every step are merged at load; step-gated ones are re-merged in "
+                         "place at the (few) step boundaries — ~80 ms each on medium, no "
+                         "extra memory, every step runs at full speed. The adapter is a "
+                         ".safetensors file (SA3-native train_lora.py / underfit output) or "
+                         "a PEFT adapter directory (with its adapter_config.json). ONLY "
+                         ".safetensors is accepted — a pickle .ckpt/.pt is refused (it would "
+                         "execute code on load). The adapter's base must match --dit.")
     ap.add_argument("--lora-strength", type=float, default=1.0,
-                    help="Application weight for every --lora delta (default 1.0). 0 disables "
-                         "the adapter (bit-identical to no LoRA); >1 amplifies it.")
+                    help="Default strength for --lora adapters without their own strength= "
+                         "(default 1.0). 0 disables (bit-identical to no LoRA); >1 amplifies.")
 
     # ── Sampling ──────────────────────────────────────────────────────────────
     ap.add_argument("--seconds", type=float, default=30.0,
@@ -463,6 +471,16 @@ def main():
     args = ap.parse_args()
     if args.steps < 1:
         ap.error(f"--steps must be ≥ 1 (got {args.steps})")
+
+    # Parse --lora groups into specs (fail fast, before any model loads).
+    args.lora_specs = None
+    if args.lora:
+        from models.defs.lora_merge import parse_lora_spec, LoraError
+        try:
+            args.lora_specs = [parse_lora_spec(toks, args.lora_strength)
+                               for toks in args.lora]
+        except LoraError as e:
+            ap.error(str(e))
 
     args = prompt_user_if_missing(args)
     if args.prompt is None:
@@ -578,6 +596,16 @@ def main():
     t0 = time.time()
     padding_emb, secs_embedder = load_conditioner_from_npz(
         str(ensure_local(DIT_CHOICES[args.dit]["ckpt"])), prefix="cond.")
+    if args.lora_specs:
+        # The conditioner is loaded straight from the npz, so the DiT-side merge
+        # never reaches it — apply any seconds-conditioner deltas (underfit
+        # adapters carry one) to the live embedder here. Whole-generation:
+        # conditioning runs once, before sampling, so steps= cannot gate it.
+        from models.defs.lora_merge import apply_conditioner_lora
+        secs_embedder.W, _n_cond = apply_conditioner_lora(secs_embedder.W,
+                                                          args.lora_specs)
+        if _n_cond:
+            sub(f"lora  conditioner delta applied ({_n_cond} adapter(s), whole generation)")
     embeds = embeds.astype(dtype)
     embeds_padded = apply_prompt_padding(embeds, mask, padding_emb.astype(dtype))
     seconds_embed = secs_embedder(args.seconds).astype(dtype)              # (1, 1, 768)
@@ -653,11 +681,15 @@ def main():
 
     # ── 3b. DiT pingpong sampling ──
     stage("[3/5]", f"DiT — load + sample ({args.steps} steps, σmax={sigma_max:.2f})")
-    if args.lora:
-        sub(f"lora  {', '.join(os.path.basename(p.rstrip('/')) for p in args.lora)}  "
-            f"(strength {args.lora_strength:g})")
+    if args.lora_specs:
+        for s in args.lora_specs:
+            rng = s["steps"]
+            rng_str = ("all steps" if rng is None else
+                       f"steps {rng[0] or 1}-{rng[1] if rng[1] is not None else args.steps}")
+            sub(f"lora  {os.path.basename(s['path'].rstrip('/'))}  "
+                f"(strength {s['strength']:g}, {rng_str})")
     t0 = time.time(); dit_model, _ = load_dit(args.dit, T_lat=T_lat, dtype=dtype,
-                                              lora_paths=args.lora, lora_strength=args.lora_strength)
+                                              lora_specs=args.lora_specs, num_steps=args.steps)
     _stage_peak_b('DiT load')
     sub(f"load {time.time()-t0:.1f}s")
 
@@ -746,8 +778,10 @@ def main():
         sys.stdout.flush()
 
     t0 = time.time()
+    _lora_plan = getattr(dit_model, "_lora_plan", None)
     latents = sample_flow_pingpong(model_fn, noise, sigmas, seed=args.seed + 1,
-                                    paste_back=paste_back, on_step=_on_step)
+                                    paste_back=paste_back, on_step=_on_step,
+                                    before_step=_lora_plan.sync if _lora_plan else None)
     mx.eval(latents)
     sample_ms = (time.time()-t0)*1000
     # Clear the progress line, then print the final summary in its place.

--- a/optimized/mlx/scripts/test_lora_merge.py
+++ b/optimized/mlx/scripts/test_lora_merge.py
@@ -1,0 +1,217 @@
+"""Unit tests for models/defs/lora_merge.py — the LoRA merge-at-load math.
+
+Pure-numpy/MLX, no model weights or torch needed. Run either way:
+
+    python scripts/test_lora_merge.py          # standalone (no pytest needed)
+    pytest scripts/test_lora_merge.py
+
+Correctness is established by:
+  * the zero-init -> identity invariant for every adapter type (a strong guard on
+    axis / reshape / transpose bugs: with B/M_xs zeroed and magnitudes at their
+    init values, every forward must return W0);
+  * an exact independent reconstruction for standard LoRA and PEFT;
+  * the Conv1d (out,k,in) <-> PyTorch (out,in,k) layout round-trip;
+  * the to_local_embed name remap;
+  * --lora-strength scaling and the bit-exact strength-0 bypass;
+  * the trust boundary (pickle refusal) and base-mismatch / 0-merge handling.
+"""
+import json
+import os
+import sys
+import tempfile
+
+import numpy as np
+import mlx.core as mx
+
+# Import lora_merge the same way the CLI does (REPO = optimized/mlx on sys.path).
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO)
+from models.defs import lora_merge as lm  # noqa: E402
+
+rng = np.random.default_rng(0)
+
+
+def _save_native(path, layer, params, cfg):
+    d = {f"{layer}.parametrizations.weight.0.{k}": mx.array(v.astype(np.float32))
+         for k, v in params.items()}
+    mx.save_safetensors(path, d, metadata={"lora_config": json.dumps(cfg)})
+
+
+def _init_params(adapter_type, W0, rank, nonzero):
+    """Init so a zeroed core -> identity; if nonzero, give a real core."""
+    fo, fi = W0.shape
+    p = {}
+    if not adapter_type.endswith("-xs"):
+        p["lora_A"] = rng.standard_normal((rank, fi)).astype(np.float32)
+        p["lora_B"] = (rng.standard_normal((fo, rank)) if nonzero
+                       else np.zeros((fo, rank))).astype(np.float32)
+    else:
+        p["M_xs"] = (rng.standard_normal((rank, rank)) if nonzero
+                     else np.zeros((rank, rank))).astype(np.float32)
+    if "magnitude" in lm._PARAMS_FOR[adapter_type]:
+        nd = 1 if "rows" in adapter_type else 0
+        p["magnitude"] = np.linalg.norm(W0, axis=nd).astype(np.float32)
+    if "magnitude_r" in lm._PARAMS_FOR[adapter_type]:
+        p["magnitude_r"] = np.linalg.norm(W0, axis=1).astype(np.float32)
+        p["magnitude_c"] = np.linalg.norm(W0, axis=0).astype(np.float32)
+    return p
+
+
+def _np(arr):
+    return np.array(arr.astype(mx.float32))
+
+
+def test_trust_boundary_refuses_pickle():
+    for bad in ("evil.ckpt", "evil.pt", "evil.bin", "weights.npz"):
+        try:
+            lm._load_safetensors(bad)
+            assert False, f"should have refused {bad}"
+        except lm.LoraError:
+            pass
+
+
+def test_all_types_zero_init_identity_and_nonzero_delta():
+    W0 = rng.standard_normal((6, 8)).astype(np.float32)
+    with tempfile.TemporaryDirectory() as tmp:
+        for atype in lm._PARAMS_FOR:
+            path = os.path.join(tmp, f"{atype}.safetensors")
+            # zero-init -> identity
+            _save_native(path, "foo", _init_params(atype, W0, 4, nonzero=False),
+                         {"adapter_type": atype, "rank": 4, "alpha": 4})
+            w = {"foo.weight": mx.array(W0)}
+            lm.merge_loras_into_weights(w, [path])
+            assert np.allclose(_np(w["foo.weight"]), W0, atol=1e-4), f"{atype} identity"
+            # nonzero core -> finite, changed
+            _save_native(path, "foo", _init_params(atype, W0, 4, nonzero=True),
+                         {"adapter_type": atype, "rank": 4, "alpha": 4})
+            w = {"foo.weight": mx.array(W0)}
+            lm.merge_loras_into_weights(w, [path])
+            got = _np(w["foo.weight"])
+            assert np.isfinite(got).all() and not np.allclose(got, W0), f"{atype} delta"
+
+
+def test_standard_lora_exact_and_strength():
+    W0 = rng.standard_normal((6, 8)).astype(np.float32)
+    A = rng.standard_normal((4, 8)).astype(np.float32)
+    B = rng.standard_normal((6, 4)).astype(np.float32)
+    expect = W0 + (8.0 / 4.0) * (B @ A)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "std.safetensors")
+        _save_native(path, "foo", {"lora_A": A, "lora_B": B},
+                     {"adapter_type": "lora", "rank": 4, "alpha": 8})
+        w = {"foo.weight": mx.array(W0)}
+        lm.merge_loras_into_weights(w, [path])
+        assert np.allclose(_np(w["foo.weight"]), expect, atol=1e-4)
+        # strength 0.5 halves the delta; strength 0 is the original
+        w = {"foo.weight": mx.array(W0)}
+        lm.merge_loras_into_weights(w, [path], strength=0.5)
+        assert np.allclose(_np(w["foo.weight"]), W0 + 0.5 * (8.0 / 4.0) * (B @ A), atol=1e-4)
+        w = {"foo.weight": mx.array(W0)}
+        lm.merge_loras_into_weights(w, [path], strength=0.0)
+        assert np.allclose(_np(w["foo.weight"]), W0, atol=1e-6)
+
+
+def test_conv1d_layout_round_trip():
+    out_c, k_c, in_c = 4, 1, 3
+    Wc = rng.standard_normal((out_c, k_c, in_c)).astype(np.float32)   # MLX layout
+    Ac = rng.standard_normal((2, in_c * k_c)).astype(np.float32)
+    Bc = rng.standard_normal((out_c, 2)).astype(np.float32)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "conv.safetensors")
+        _save_native(path, "conv", {"lora_A": Ac, "lora_B": Bc},
+                     {"adapter_type": "lora", "rank": 2, "alpha": 2})
+        w = {"conv.weight": mx.array(Wc)}
+        lm.merge_loras_into_weights(w, [path])
+        got = _np(w["conv.weight"])
+        expect = Wc + (Bc @ Ac).reshape(out_c, in_c, k_c).transpose(0, 2, 1)
+        assert got.shape == Wc.shape and np.allclose(got, expect, atol=1e-4)
+
+
+def test_to_local_embed_remap():
+    Wt = rng.standard_normal((5, 5)).astype(np.float32)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "tle.safetensors")
+        _save_native(path, "transformer.layers.0.to_local_embed.0",
+                     {"lora_A": rng.standard_normal((2, 5)).astype(np.float32),
+                      "lora_B": rng.standard_normal((5, 2)).astype(np.float32)},
+                     {"adapter_type": "lora", "rank": 2, "alpha": 2})
+        w = {"transformer.layers.0.to_local_embed.seq.0.weight": mx.array(Wt)}
+        stats = lm.merge_loras_into_weights(w, [path])
+        assert stats["merged"] == 1 and not stats["skipped"]
+
+
+def test_peft_format_exact():
+    W0 = rng.standard_normal((6, 8)).astype(np.float32)
+    A = rng.standard_normal((4, 8)).astype(np.float32)
+    B = rng.standard_normal((6, 4)).astype(np.float32)
+    with tempfile.TemporaryDirectory() as tmp:
+        with open(os.path.join(tmp, "adapter_config.json"), "w") as fh:
+            json.dump({"peft_type": "LORA", "r": 4, "lora_alpha": 8, "use_dora": False}, fh)
+        mx.save_safetensors(
+            os.path.join(tmp, "adapter_model.safetensors"),
+            {"base_model.model.foo.lora_A.weight": mx.array(A),
+             "base_model.model.foo.lora_B.weight": mx.array(B)},
+            metadata={"format": "pt"})
+        w = {"foo.weight": mx.array(W0)}
+        stats = lm.merge_loras_into_weights(w, [tmp])   # directory input
+        assert stats["merged"] == 1
+        assert np.allclose(_np(w["foo.weight"]), W0 + (8.0 / 4.0) * (B @ A), atol=1e-4)
+
+
+def test_unknown_layers_skipped_base_untouched():
+    W0 = rng.standard_normal((6, 8)).astype(np.float32)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "std.safetensors")
+        _save_native(path, "foo",
+                     {"lora_A": rng.standard_normal((4, 8)).astype(np.float32),
+                      "lora_B": rng.standard_normal((6, 4)).astype(np.float32)},
+                     {"adapter_type": "lora", "rank": 4, "alpha": 4})
+        w = {"other.weight": mx.array(W0)}
+        msgs = []
+        stats = lm.merge_loras_into_weights(w, [path], log=msgs.append)
+        assert stats["merged"] == 0 and stats["skipped"] == ["foo"]
+        assert np.allclose(_np(w["other.weight"]), W0)
+        # a 0-merge run must warn, not look like a successful no-op
+        assert any("WARNING" in m and "0 layers" in m for m in msgs)
+
+
+def test_base_mismatch_raises_clear_error():
+    # base is (6, 8) but the adapter was trained for an (10, 8) layer
+    W0 = rng.standard_normal((6, 8)).astype(np.float32)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "mismatch.safetensors")
+        _save_native(path, "foo",
+                     {"lora_A": rng.standard_normal((4, 8)).astype(np.float32),
+                      "lora_B": rng.standard_normal((10, 4)).astype(np.float32)},
+                     {"adapter_type": "lora", "rank": 4, "alpha": 4})
+        w = {"foo.weight": mx.array(W0)}
+        try:
+            lm.merge_loras_into_weights(w, [path])
+            assert False, "should have raised on base mismatch"
+        except lm.LoraError as e:
+            assert "foo" in str(e) and "base" in str(e).lower()
+
+
+def test_svd_bases_orthonormal():
+    Wsvd = rng.standard_normal((6, 8)).astype(np.float32)
+    U, V = lm._svd_bases(Wsvd, rank=6)
+    assert np.allclose(U.T @ U, np.eye(6), atol=1e-4)
+    assert np.allclose(V.T @ V, np.eye(6), atol=1e-4)
+
+
+def _main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = []
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  FAIL {t.__name__}: {e}")
+            failed.append(t.__name__)
+    print("\n" + ("ALL PASS" if not failed else f"FAILURES: {failed}"))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/optimized/mlx/scripts/test_lora_merge.py
+++ b/optimized/mlx/scripts/test_lora_merge.py
@@ -199,6 +199,43 @@ def test_svd_bases_orthonormal():
     assert np.allclose(V.T @ V, np.eye(6), atol=1e-4)
 
 
+def test_underfit_wrapper_prefixes():
+    """Underfit (github.com/dada-bots/underfit) saves full-wrapper layer names:
+    DiT layers as ``model.transformer...`` and the seconds conditioner as
+    ``conditioners.seconds_total.embedder.embedding.1``. Both must land on the
+    bare npz keys; bare names keep working."""
+    W_dit = rng.standard_normal((6, 8)).astype(np.float32)
+    W_cond = rng.standard_normal((5, 7)).astype(np.float32)
+    A_d = rng.standard_normal((4, 8)).astype(np.float32)
+    B_d = rng.standard_normal((6, 4)).astype(np.float32)
+    A_c = rng.standard_normal((4, 7)).astype(np.float32)
+    B_c = rng.standard_normal((5, 4)).astype(np.float32)
+    cfg = {"adapter_type": "lora", "rank": 4, "alpha": 4}
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "underfit.safetensors")
+        d = {}
+        for layer, (A, B) in {
+            "model.transformer.layers.0.self_attn.to_qkv": (A_d, B_d),
+            "conditioners.seconds_total.embedder.embedding.1": (A_c, B_c),
+        }.items():
+            d[f"{layer}.parametrizations.weight.0.lora_A"] = mx.array(A)
+            d[f"{layer}.parametrizations.weight.0.lora_B"] = mx.array(B)
+        mx.save_safetensors(path, d, metadata={"lora_config": json.dumps(cfg)})
+        w = {"transformer.layers.0.self_attn.to_qkv.weight": mx.array(W_dit),
+             "cond.seconds_total_weight": mx.array(W_cond)}
+        stats = lm.merge_loras_into_weights(w, [path])
+        assert stats["merged"] == 2 and not stats["skipped"], stats
+        assert np.allclose(_np(w["transformer.layers.0.self_attn.to_qkv.weight"]),
+                           W_dit + B_d @ A_d, atol=1e-4)
+        assert np.allclose(_np(w["cond.seconds_total_weight"]),
+                           W_cond + B_c @ A_c, atol=1e-4)
+    # bare names still pass through, and model.-prefixed to_local_embed remaps
+    assert lm._layer_to_npz_key("transformer.layers.3.ff.ff.2") == \
+        "transformer.layers.3.ff.ff.2.weight"
+    assert lm._layer_to_npz_key("model.transformer.layers.3.to_local_embed.0") == \
+        "transformer.layers.3.to_local_embed.seq.0.weight"
+
+
 def _main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = []

--- a/optimized/mlx/scripts/test_lora_merge.py
+++ b/optimized/mlx/scripts/test_lora_merge.py
@@ -236,6 +236,170 @@ def test_underfit_wrapper_prefixes():
         "transformer.layers.3.to_local_embed.seq.0.weight"
 
 
+def test_lora_spec_parser():
+    s = lm.parse_lora_spec(["a.safetensors"], default_strength=0.5)
+    assert s == {"path": "a.safetensors", "strength": 0.5, "steps": None}
+    s = lm.parse_lora_spec(["a.safetensors", "strength=0.8", "steps=2-8"])
+    assert s["strength"] == 0.8 and s["steps"] == (2, 8)
+    assert lm.parse_lora_spec(["a", "steps=2-"])["steps"] == (2, None)
+    assert lm.parse_lora_spec(["a", "steps=-4"])["steps"] == (None, 4)
+    assert lm.parse_lora_spec(["a", "steps=3"])["steps"] == (3, 3)
+    for bad in (["a.st", "b.st"],            # two paths in one flag
+                ["a", "steps=8-2"],          # min > max
+                ["a", "steps=0-3"],          # 1-based
+                ["a", "steps=-"],            # empty range
+                ["a", "strength=loud"],      # not a float
+                []):
+        try:
+            lm.parse_lora_spec(bad)
+            assert False, f"should have rejected {bad}"
+        except lm.LoraError:
+            pass
+    # resolve against an 8-step schedule (0-based inclusive out)
+    assert lm.resolve_steps(None, 8) == (0, 7)
+    assert lm.resolve_steps((2, 8), 8) == (1, 7)
+    assert lm.resolve_steps((2, None), 8) == (1, 7)
+    assert lm.resolve_steps((None, 4), 8) == (0, 3)
+    assert lm.resolve_steps((2, 99), 8) == (1, 7)      # clamp
+    assert lm.resolve_steps((9, None), 8) is None      # misses the schedule
+
+
+class _StubModule:
+    """Bare object with .weight — stands in for nn.Linear in plan tests."""
+    def __init__(self, w):
+        self.weight = w
+
+
+def _stub_tree(weights):
+    """Build a walkable module tree for keys like 'foo.weight' and
+    'layers.0.lin.weight' (digits = list containers, as in the DiT)."""
+    class _NS:  # namespace node
+        pass
+    root = _NS()
+    for key, w in weights.items():
+        parts = key.split(".")[:-1]          # drop trailing 'weight'
+        obj = root
+        for j, p in enumerate(parts[:-1]):
+            nxt = parts[j + 1]
+            if p.isdigit():
+                obj = obj[int(p)]
+            else:
+                if not hasattr(obj, p):
+                    setattr(obj, p, [] if nxt.isdigit() else _NS())
+                obj = getattr(obj, p)
+            if isinstance(obj, list) and nxt.isdigit():
+                while len(obj) <= int(nxt):
+                    obj.append(_NS())
+        last = parts[-1]
+        mod = _StubModule(w)
+        if last.isdigit():
+            obj[int(last)] = mod
+        else:
+            setattr(obj, last, mod)
+    return root
+
+
+def test_step_plan_matches_reference():
+    """For every adapter type: gate two overlapping adapters across an 8-step
+    schedule and check the in-place weights at EVERY step against the from-
+    scratch reference W0 + Σ_active strength·(merged − W0)."""
+    num_steps = 8
+    K1, K2 = "foo.weight", "layers.0.lin.weight"
+    W = {K1: rng.standard_normal((6, 8)).astype(np.float32),
+         K2: rng.standard_normal((5, 7)).astype(np.float32)}
+    with tempfile.TemporaryDirectory() as tmp:
+        for atype in lm._PARAMS_FOR:
+            p1 = os.path.join(tmp, f"{atype}-1.safetensors")
+            p2 = os.path.join(tmp, f"{atype}-2.safetensors")
+            prm = {k: _init_params(atype, w, 3, nonzero=True) for k, w in W.items()}
+            d = {}
+            for k, w in W.items():
+                layer = k[: -len(".weight")]
+                for pk, pv in prm[k].items():
+                    d[f"{layer}.parametrizations.weight.0.{pk}"] = mx.array(pv)
+            mx.save_safetensors(p1, d, metadata={"lora_config": json.dumps(
+                {"adapter_type": atype, "rank": 3, "alpha": 3})})
+            prm2 = {K1: _init_params("lora", W[K1], 3, nonzero=True)}
+            d2 = {f"foo.parametrizations.weight.0.{pk}": mx.array(pv)
+                  for pk, pv in prm2[K1].items()}
+            mx.save_safetensors(p2, d2, metadata={"lora_config": json.dumps(
+                {"adapter_type": "lora", "rank": 3, "alpha": 3})})
+
+            specs = [{"path": p1, "strength": 0.7, "steps": (2, 5)},
+                     {"path": p2, "strength": 1.3, "steps": (4, None)}]
+            weights = {k: mx.array(w) for k, w in W.items()}
+            plan = lm.prepare_loras(weights, specs, num_steps=num_steps)
+            assert plan is not None and len(plan.layers) == 2
+
+            model = _stub_tree(weights)
+            plan.attach(model)
+            mods = {K1: model.foo, K2: model.layers[0].lin}
+
+            def ref(i):
+                out = {k: W[k].copy() for k in W}
+                if 1 <= i <= 4:  # adapter 1 (steps 2-5, 0-based 1..4)
+                    for k in W:
+                        m = lm._merged_weight(W[k], prm[k], atype, 1.0)
+                        out[k] += 0.7 * (m - W[k])
+                if i >= 3:       # adapter 2 (steps 4-, 0-based 3..7)
+                    m = lm._merged_weight(W[K1], prm2[K1], "lora", 1.0)
+                    out[K1] += 1.3 * (m - W[K1])
+                return out
+
+            for i in range(num_steps):
+                plan.sync(i)
+                expect = ref(i)
+                for k in W:
+                    got = _np(mods[k].weight)
+                    err = np.abs(got - expect[k]).max()
+                    assert err < 1e-3, f"{atype} step {i} {k}: max|d|={err:.2e}"
+
+
+def test_step_plan_round_trip_drift():
+    """50 on/off gating cycles on fp16 weights must not accumulate drift
+    (exact-inverse pairing — measured frozen-after-cycle-1 in the design
+    benchmarks; this guards the implementation)."""
+    K = "foo.weight"
+    W0 = rng.standard_normal((32, 48)).astype(np.float16)
+    prm = _init_params("dora-rows", W0.astype(np.float32), 4, nonzero=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "d.safetensors")
+        _save_native(path, "foo", prm, {"adapter_type": "dora-rows", "rank": 4, "alpha": 4})
+        weights = {K: mx.array(W0)}
+        plan = lm.prepare_loras(weights, [{"path": path, "strength": 1.0,
+                                           "steps": (2, None)}], num_steps=2)
+        model = _stub_tree(weights)
+        plan.attach(model)
+        drift1 = None
+        for cyc in range(50):
+            plan.sync(1)   # on
+            plan.sync(0)   # off
+            d = np.abs(_np(model.foo.weight) - W0.astype(np.float32)).max()
+            if cyc == 0:
+                drift1 = d
+        assert d <= drift1 + 1e-6, f"drift grew: cycle1 {drift1:.2e} → cycle50 {d:.2e}"
+        rel = (np.linalg.norm(_np(model.foo.weight) - W0.astype(np.float32))
+               / np.linalg.norm(W0.astype(np.float32)))
+        assert rel < 5e-3, f"round-trip rel drift {rel:.2e}"
+
+
+def test_full_interval_uses_merge_path():
+    """Specs without steps= (or covering every step) → no plan; weights match
+    the plain merge_loras_into_weights result exactly."""
+    W0 = rng.standard_normal((6, 8)).astype(np.float32)
+    prm = _init_params("lora", W0, 4, nonzero=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "l.safetensors")
+        _save_native(path, "foo", prm, {"adapter_type": "lora", "rank": 4, "alpha": 4})
+        wa = {"foo.weight": mx.array(W0)}
+        wb = {"foo.weight": mx.array(W0)}
+        plan = lm.prepare_loras(wa, [{"path": path, "strength": 0.6,
+                                      "steps": (1, 8)}], num_steps=8)
+        assert plan is None
+        lm.merge_loras_into_weights(wb, [path], strength=0.6)
+        assert np.array_equal(_np(wa["foo.weight"]), _np(wb["foo.weight"]))
+
+
 def _main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = []

--- a/optimized/mlx/scripts/test_lora_merge.py
+++ b/optimized/mlx/scripts/test_lora_merge.py
@@ -400,6 +400,34 @@ def test_full_interval_uses_merge_path():
         assert np.array_equal(_np(wa["foo.weight"]), _np(wb["foo.weight"]))
 
 
+def test_gate_all_and_clear_restore_base():
+    """The gradio path: gate_all=True routes even full-range adapters through
+    the plan so clear() can restore a cached model to base in place; an adapter
+    matching zero layers raises a clear wrong-base error."""
+    W0 = rng.standard_normal((6, 8)).astype(np.float32)
+    prm = _init_params("dora-rows", W0, 4, nonzero=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "g.safetensors")
+        _save_native(path, "foo", prm, {"adapter_type": "dora-rows", "rank": 4, "alpha": 4})
+        w = {"foo.weight": mx.array(W0)}
+        plan = lm.prepare_loras(w, [{"path": path, "strength": 1.0, "steps": None}],
+                                num_steps=8, gate_all=True)
+        assert plan is not None, "gate_all must plan-manage full-range adapters"
+        model = _stub_tree(w)
+        plan.attach(model)
+        assert not np.allclose(_np(model.foo.weight), W0), "step-1 state not applied"
+        plan.clear()
+        assert np.abs(_np(model.foo.weight) - W0).max() < 1e-4, "clear() must restore base"
+        # an adapter whose layers don't exist in the target → clear error
+        w2 = {"bar.weight": mx.array(W0)}
+        try:
+            lm.prepare_loras(w2, [{"path": path, "strength": 1.0, "steps": (2, None)}],
+                             num_steps=8)
+            assert False, "zero-match adapter should raise"
+        except lm.LoraError as e:
+            assert "different base model" in str(e)
+
+
 def _main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = []


### PR DESCRIPTION
LoRA inference for the MLX path: merge-at-load (from #57), underfit checkpoint support, per-step gating with per-adapter strength + step ranges, and a gradio LoRA section.

**Supersedes #57** — @brxs's two commits are included verbatim (cherry-picked onto current main, authorship preserved) and everything here builds on them. If this is squash-merged, please keep the `Co-authored-by: brxs <deathxgriphc@gmail.com>` trailer.

## What's here

### 1. LoRA merge-at-load (#57, rebased)
Adapters merge into the DiT weight dict at load — no runtime parametrization, no per-step cost, strength 0 is a bit-exact bypass. All nine adapter types (lora, dora-rows/cols, bora, the four -xs variants), SA3-native and PEFT formats, safetensors-only trust boundary.

### 2. Underfit checkpoint support
[underfit](https://github.com/dada-bots/underfit) saves adapters with full-wrapper layer names (`model.transformer...`, `conditioners.seconds_total.embedder.embedding.1`). The merge previously mapped names verbatim, so a real underfit adapter merged **0/169 layers** and silently generated with the base model. Now the `model.` prefix is stripped and the seconds-conditioner layer maps onto its baked npz key. Verified against a real underfit dora-rows adapter: 169/169 layers merge, dora math matches an fp64 hand-computation (rel 5.5e-8).

Also fixed: conditioner deltas were inert even when merged — the conditioner loads `cond.*` straight from the npz file, not from the DiT weight dict. They now apply to the live seconds embedder (whole-generation; conditioning runs once, before sampling).

### 3. Per-step gating
```
--lora ADAPTER [strength=S] [steps=MIN-MAX]     # repeatable, one adapter per flag
--lora plini.safetensors strength=0.8 steps=2-  # skip the first step
```
`steps=` is 1-based inclusive: `2-8`, `2-` (2..last), `-4` (1..4), `3`. Skipping the first LoRA step often improves results; adapters can stack with different ranges.

Mechanism: full-range adapters keep the plain merge path (bit-identical output). Step-gated adapters are **re-merged in place at the step boundaries** where the active set changes, using a closed form that needs no stored base weights:

```
strength·(merged − W0) = strength·(α βᵀ − 1) ⊙ W0 + B′ @ A′
W_new = (W_cur − LR_S) · (M_S′ / M_S) + LR_S′
```

All nine adapter types reduce to this form (α/β are the DoRA/BoRA magnitude scale vectors, absent for plain LoRA). Costs, measured: **~26 ms (small) / ~80 ms (medium) per boundary** — a quarter of one sampling step, at most steps−1 times per generation — with ~40 MB of rank factors and zero extra weight memory. Every step runs the plain forward at full speed. This won a benchmark against the alternatives: a runtime LoRA wrapper costs +13–15% on *every* step, and caching per-step weight variants costs 6.8–21.6 GB. Every transition routes through base, so fp16 round-trip drift is bounded (frozen after the first cycle for on/off gating; guarded by a unit test).

Plumbing: `lora_merge.LoraStepPlan` built at load while the pristine weight dict is available, attached to the live modules after construction (plain attribute rebinding; nothing in this pipeline is `mx.compile`d), driven by a new `before_step(i)` hook in `sample_flow_pingpong` that mirrors the existing `on_step`.

### 4. Gradio LoRA section
New **LoRA** accordion in the MLX web UI: starts empty, `+ Add LoRA` reveals up to three adapters, each a two-row group — file upload + remove, then strength / min-step / max-step sliders (range sliders track the Steps setting; max at the top = last step).

Cached DiTs never reload for LoRA changes: the cached model keeps base weights plus its step plan, and a config change does an exact-inverse clear back to base followed by a fresh plan from the live module weights — one in-place transition each way, so tweaking strength between generations is effectively free (vs ~11 s for a reload+merge on medium). Wrong-base adapters fail with a clear message in the UI error box (layer + both shapes; a zero-match adapter reports "trained for a different base model" instead of silently sampling the base).

## Verification

- 16 unit tests in `scripts/test_lora_merge.py` (`python scripts/test_lora_merge.py`, no pytest needed): per-step weight equivalence vs a from-scratch reference for all nine adapter types, 50-cycle round-trip drift guard, spec-grammar cases, underfit prefix mapping, gate-all/clear restore, plus #57's original suite.
- E2E on a real underfit dora-rows adapter (medium, fixed seed): `steps=2-8` (1 boundary), stacked adapters with overlapping ranges (2 boundaries), full-range identical to the plain merge path; boundary overhead invisible in wall time (~328 vs ~325 ms/step).
- Gradio path driven end-to-end through the API: gated generation with the lora tag in the output metadata, wrong-base error box, strength-tweak fast path, base restoration after adapter removal.
