### PR TITLE
tflite: LoRA inference + gradio web UI (parity with MLX)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ wandb/*
 .DS_Store
 *.safetensors
 .claude
+# LoRA-merged DiT cache (patched copies; regenerated on demand)
+optimized/tflite/models/tflite/lora_cache/

--- a/optimized/tflite/.gitignore
+++ b/optimized/tflite/.gitignore
@@ -5,6 +5,13 @@
 
 # Generated audio — anywhere on the tree, including output/.
 *.wav
+*.mp3
+output/
+
+# LoRA adapter library (user .safetensors, scanned by the gradio dropdown) and
+# the LoRA-merged DiT cache (patched multi-GB copies, regenerated on demand).
+loras/
+lora_cache/
 
 # Python virtualenv created by install.sh
 .venv/

--- a/optimized/tflite/README.md
+++ b/optimized/tflite/README.md
@@ -253,6 +253,8 @@ For sub-realtime latency on a supported device, prefer the GPU siblings:
 | `--cfg`               | 1.0      | Guidance scale; 1.0 = off, >1 toward prompt, <1 toward uncond. ≠1 runs cond+uncond each step |
 | `--apg`               | 1.0      | Adaptive Projected Guidance; only matters when `--cfg ≠ 1`            |
 | `--cfg-batched`       | on       | When `--cfg ≠ 1`, run cond+uncond as one batch=2 invoke on the variable-batch DiT (~7–29% faster on Apple-Silicon AMX). `--no-cfg-batched` → sequential batch=1 dual-pass. Bit-identical at `fp32`/`w8a32` — see [Precision variants](#precision-variants---precision) for `w16a32`/`w8a8-dyn` |
+| `--lora`              | —        | A `.safetensors` LoRA adapter (SA3-native/underfit or PEFT) merged into the DiT, optional `strength=S`; repeat to stack. Requires `--dit-precision fp32` or `w16a32`. See [LoRA](#lora) |
+| `--lora-strength`     | 1.0      | Default strength for `--lora` adapters without their own `strength=`  |
 | `--init-audio`        | —        | WAV (any format via ffmpeg) input for audio-to-audio / inpaint       |
 | `--init-noise-level`  | 1.0      | σmax; 0.4–0.8 typical for variation, 1.0 = full regen, >1 = overshoot |
 | `--inpaint-range`     | —        | `START,END` seconds; regenerate that span, keep the rest              |
@@ -265,6 +267,34 @@ All `.tflite` models are **fp32** except T5Gemma, which is **fp16** (numerically
 lossless there). There is no dtype knob: on CPU, int8/fp16 weights buy size, not
 speed (XNNPACK dequantizes to fp32 to matmul), and int8 costs quality on the DiT
 — so this release ships the fp32 graphs directly. (See "Notes on the design".)
+
+## LoRA
+
+Apply a LoRA finetune by merging it into the DiT's weight buffers at load —
+same adapters and semantics as the MLX backend's `--lora`:
+
+```bash
+# one adapter
+./sa3 --dit medium --decoder same-l --prompt "progressive metal" \
+      --lora plini-sa3-380.safetensors
+
+# per-adapter strength; stack several
+./sa3 --dit medium --decoder same-l --prompt "..." \
+      --lora a.safetensors strength=0.8 --lora b.safetensors strength=0.5
+```
+
+The adapter is a `.safetensors` file (SA3-native `train_lora.py` / underfit
+output, or a PEFT adapter directory) — pickle `.ckpt/.pt` is refused. All nine
+adapter types (lora, dora-rows/cols, bora, the four -xs) are supported; the base
+must match `--dit`. The merge is written into a cached copy of the DiT under
+`models/tflite/lora_cache/` (keyed by adapter + strength content hash) and reused
+on repeat runs, so the ~5–15 s patch cost is paid once. A medium fp32 cache entry
+is ~5.4 GB — delete `lora_cache/` to reclaim.
+
+Requires `--dit-precision fp32` (default) or `w16a32`. Quantized-int8 DiTs
+(`w8a32` / `w8a8-dyn` / `w4a32`) can't be LoRA-merged (it would destroy the GPTQ
+grid). **Per-step gating (`steps=`) is MLX-only** — a frozen TFLite graph merges
+weights once at load; use `optimized/mlx` for step-gated LoRA.
 
 ## Files
 

--- a/optimized/tflite/README.md
+++ b/optimized/tflite/README.md
@@ -219,6 +219,35 @@ printed prominently as a `▸ saved` line at the end of each run.
 
 Use `--threads` to control the XNNPACK CPU thread count (default 8).
 
+## Web UI (gradio)
+
+A browser UI over the same TFLite backend — every generation mode plus a
+spectrogram player, a history panel, and playback options (auto-play, infinite
+radio with pre-generation, loop, hotswap, MP3/WAV save).
+
+```bash
+./sa3-gradio                       # sm-music, opens a public share link
+./sa3-gradio --dit medium          # start on the medium DiT
+./sa3-gradio --no-share            # local-only (http://localhost:7860)
+./sa3-gradio --port 7871           # pick the port
+```
+
+`./sa3-gradio` is a wrapper around `.venv/bin/python scripts/sa3_gradio.py`; on
+first run it offers to install the UI-only extras (`gradio`, `pillow`,
+`soundfile`) into `.venv`. In the browser:
+
+- **Precision** dropdown next to the model picker — `fp32` (default) / `w16a32`
+  / `w8a32` / `w8a8-dyn`, applied to the DiT + codec.
+- **LoRA** panel — upload a `.safetensors` adapter or pick one from
+  `loras/<model>/` (e.g. `loras/sa3-medium/`), set its strength, stack several;
+  settings are remembered per model. The panel is disabled under a quantized
+  precision (see the LoRA note above) and has no per-step range (frozen graph).
+- **Audio-to-audio / inpainting** — upload a reference clip; inpainting adds a
+  start/end range. Both are combinable.
+
+Generated WAV/MP3s land in `output/gradio/`. First use of a model/precision
+loads its weights (cached after).
+
 ### Without the wrapper
 
 ```bash
@@ -291,10 +320,16 @@ must match `--dit`. The merge is written into a cached copy of the DiT under
 on repeat runs, so the ~5–15 s patch cost is paid once. A medium fp32 cache entry
 is ~5.4 GB — delete `lora_cache/` to reclaim.
 
-Requires `--dit-precision fp32` (default) or `w16a32`. Quantized-int8 DiTs
-(`w8a32` / `w8a8-dyn` / `w4a32`) can't be LoRA-merged (it would destroy the GPTQ
-grid). **Per-step gating (`steps=`) is MLX-only** — a frozen TFLite graph merges
-weights once at load; use `optimized/mlx` for step-gated LoRA.
+Requires `--dit-precision fp32` (default) or `w16a32`. **LoRA on the quantized
+DiTs (`w8a32` / `w8a8-dyn` / `w4a32`) isn't figured out yet** — those store
+weights as GPTQ-calibrated int8, so merging would mean dequantize → add the LoRA
+delta → re-quantize, and a naive re-quant throws away the GPTQ error-feedback
+grid (you'd get a model that's both LoRA-adapted *and* degraded). Doing it well
+needs a GPTQ pass over the merged weights; until then `--lora` refuses quantized
+precisions (the CLI errors, the web UI disables the LoRA panel). Use fp32/w16a32
+for LoRA — on CPU fp32 is the fast-and-accurate choice anyway, so this is rarely
+a real constraint. **Per-step gating (`steps=`) is also MLX-only** — a frozen
+TFLite graph merges weights once at load; use `optimized/mlx` for step-gated LoRA.
 
 ## Files
 

--- a/optimized/tflite/requirements-gradio.txt
+++ b/optimized/tflite/requirements-gradio.txt
@@ -1,0 +1,4 @@
+# Extras for the gradio web UI (./sa3-gradio) — not needed by the CLI.
+gradio>=4.0
+pillow>=10.0
+soundfile>=0.12   # decode mp3/flac/24-bit/48kHz uploads without ffmpeg

--- a/optimized/tflite/sa3-gradio
+++ b/optimized/tflite/sa3-gradio
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Shortcut for running scripts/sa3_gradio.py with the project .venv.
+# All args pass through unchanged.
+#
+# Examples:
+#   ./sa3-gradio                            # sm-music + same-s, public share link
+#   ./sa3-gradio --dit medium
+#   ./sa3-gradio --no-share                 # local-only
+#   ./sa3-gradio --help
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${SCRIPT_DIR}/.venv/bin/python"
+
+if [ ! -x "$PY" ]; then
+  echo "No .venv found — run ./install.sh (or ./bootstrap.sh) first."
+  exit 1
+fi
+
+# gradio + pillow + soundfile are UI-only extras, not part of the base requirements.
+if ! "$PY" -c "import gradio, PIL, soundfile" >/dev/null 2>&1; then
+  echo "The gradio UI needs a few extra packages (gradio, pillow, soundfile)."
+  read -r -p "Install them into .venv now? [Y/n] " ans
+  case "${ans:-Y}" in
+    [Yy]*)
+      if command -v uv >/dev/null 2>&1; then
+        uv pip install -p "$PY" -r "${SCRIPT_DIR}/requirements-gradio.txt"
+      else
+        "$PY" -m pip install -r "${SCRIPT_DIR}/requirements-gradio.txt"
+      fi
+      ;;
+    *) echo "Aborted — install manually: uv pip install -p .venv/bin/python -r requirements-gradio.txt"; exit 1 ;;
+  esac
+fi
+
+exec "$PY" "${SCRIPT_DIR}/scripts/sa3_gradio.py" "$@"

--- a/optimized/tflite/scripts/lora_core.py
+++ b/optimized/tflite/scripts/lora_core.py
@@ -1,0 +1,321 @@
+"""LoRA adapter parsing + per-layer merge math — torch/mlx-free (numpy only).
+
+The TFLite route ships standalone (its own bootstrap, its own venv, runs on
+Windows), so it can't import the MLX runtime. This module is a faithful vendored
+copy of the *backend-agnostic* half of
+``optimized/mlx/models/defs/lora_merge.py`` — the safetensors parsing and the
+per-adapter-type ``W' = f(W0, adapter)`` math — with the two MLX touch-points
+replaced by pure numpy:
+
+  * safetensors is read with a ~25-line numpy reader (JSON header + a raw blob),
+    instead of ``mx.load``;
+  * everything else (``_parse_adapter``, ``_group_native``/``_group_peft``,
+    ``_merged_weight`` for all nine adapter types, ``_check_shapes``,
+    ``_svd_bases`` for the ``-xs`` variants, ``parse_lora_spec``) is copied
+    verbatim, since it was already numpy-fp32.
+
+KEEP IN SYNC with optimized/mlx/models/defs/lora_merge.py — the merge math must
+match the MLX path bit-for-bit (both mirror ``LoRAParametrization.*_forward`` in
+``stable_audio_3/models/lora/model.py``). What is intentionally NOT here: the
+MLX weight-dict merge (``merge_loras_into_weights``) and the per-step
+``LoraStepPlan`` — TFLite patches frozen FlatBuffer weight buffers instead (see
+``lora_patch.py``), and per-step gating is not feasible on a frozen graph.
+
+Trust boundary: only ``.safetensors`` adapters are accepted; a pickle
+``.ckpt``/``.pt``/``.bin`` (which ``torch.load`` would execute code from) is
+refused — this module never imports torch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+
+import numpy as np
+
+# Pickle-backed extensions we refuse to load (the trust boundary).
+_PICKLE_EXTS = (".ckpt", ".pt", ".pth", ".bin")
+
+# Adapter param names per type (mirrors utils._get_adapter_param_names).
+_PARAMS_FOR = {
+    "lora": ("lora_A", "lora_B"),
+    "dora-rows": ("lora_A", "lora_B", "magnitude"),
+    "dora-cols": ("lora_A", "lora_B", "magnitude"),
+    "bora": ("lora_A", "lora_B", "magnitude_r", "magnitude_c"),
+    "lora-xs": ("M_xs",),
+    "dora-rows-xs": ("M_xs", "magnitude"),
+    "dora-cols-xs": ("M_xs", "magnitude"),
+    "bora-xs": ("M_xs", "magnitude_r", "magnitude_c"),
+}
+
+# Underfit saves the seconds conditioner Linear under this checkpoint name; the
+# baked TFLite DiT carries it in-graph as the unique (768, 256) FULLY_CONNECTED
+# (lora_patch maps it there).
+COND_SECONDS_LAYER = "conditioners.seconds_total.embedder.embedding.1"
+
+
+class LoraError(Exception):
+    """An adapter could not be loaded or applied."""
+
+
+# ── numpy safetensors reader (no torch, no safetensors pkg) ────────────────────
+
+_ST_DTYPES = {
+    "F64": np.float64, "F32": np.float32, "F16": np.float16, "BF16": None,
+    "I64": np.int64, "I32": np.int32, "I16": np.int16, "I8": np.int8,
+    "U8": np.uint8, "BOOL": np.bool_,
+}
+
+
+def _load_safetensors(path: str):
+    """Return ``(tensors: dict[str, np.ndarray fp32], metadata: dict)``.
+
+    Refuses pickle. bf16 is widened to fp32 via a uint16<<16 bit-cast (numpy has
+    no native bf16). Every returned tensor is fp32 so the merge math is uniform.
+    """
+    lower = path.lower()
+    if lower.endswith(_PICKLE_EXTS):
+        raise LoraError(
+            f"refusing to load pickle-format adapter {os.path.basename(path)!r} — "
+            f"only .safetensors adapters are accepted (a .ckpt/.pt is unpickled by "
+            f"torch.load and can execute arbitrary code)"
+        )
+    if not lower.endswith(".safetensors"):
+        raise LoraError(f"not a .safetensors adapter: {path!r}")
+    with open(path, "rb") as f:
+        (hlen,) = struct.unpack("<Q", f.read(8))
+        hdr = json.loads(f.read(hlen))
+        blob = f.read()
+    meta = hdr.pop("__metadata__", {}) or {}
+    out: dict[str, np.ndarray] = {}
+    for k, v in hdr.items():
+        if v["dtype"] not in _ST_DTYPES:
+            raise LoraError(f"{os.path.basename(path)}: unsupported tensor dtype "
+                            f"{v['dtype']!r} for {k}")
+        b0, b1 = v["data_offsets"]
+        n = 1
+        for d in v["shape"]:
+            n *= d
+        if v["dtype"] == "BF16":
+            u = np.frombuffer(blob, np.uint16, count=n or 1, offset=b0)
+            arr = (u.astype(np.uint32) << 16).view(np.float32)
+        else:
+            arr = np.frombuffer(blob[b0:b1], _ST_DTYPES[v["dtype"]])
+        out[k] = arr.reshape(v["shape"]).astype(np.float32, copy=False)
+    return out, meta
+
+
+# ── SVD bases for -xs adapters (recomputed; mirrors model.py) ──────────────────
+
+def _canonicalize_svd_signs(U: np.ndarray, Vh: np.ndarray):
+    """Deterministic sign convention: largest-magnitude element of each U column
+    is positive (mirrors model._canonicalize_svd_signs)."""
+    max_abs_idx = np.argmax(np.abs(U), axis=0)
+    signs = np.sign(U[max_abs_idx, np.arange(U.shape[1])])
+    signs[signs == 0] = 1.0
+    return U * signs[None, :], Vh * signs[:, None]
+
+
+def _svd_bases(W0: np.ndarray, rank: int):
+    """``(U[:, :rank], V[:, :rank])`` from the SVD of W0 (fan_out, fan_in), with
+    V such that ``U @ diag(S) @ V.T`` reconstructs W0 (mirrors model.py)."""
+    U_full, _S, Vh_full = np.linalg.svd(W0, full_matrices=False)
+    U_full, Vh_full = _canonicalize_svd_signs(U_full, Vh_full)
+    return U_full[:, :rank], Vh_full[:rank, :].T
+
+
+# ── per-type merge math (numpy, float32) — mirrors lora_merge._merged_weight ───
+
+def _mag_2d(mag: np.ndarray, norm_dim: int) -> np.ndarray:
+    mag = np.atleast_1d(np.squeeze(mag))
+    return mag.reshape(-1, 1) if norm_dim == 1 else mag.reshape(1, -1)
+
+
+def merged_weight(W0: np.ndarray, p: dict, adapter_type: str, scaling: float) -> np.ndarray:
+    """LoRA-merged weight for one layer at full strength (lora_strength=1).
+    ``W0`` is (fan_out, fan_in) float32; ``p`` holds the adapter tensors."""
+    if adapter_type == "lora":
+        return W0 + scaling * (p["lora_B"] @ p["lora_A"])
+
+    if adapter_type in ("dora-rows", "dora-cols"):
+        norm_dim = 1 if adapter_type == "dora-rows" else 0
+        V = W0 + scaling * (p["lora_B"] @ p["lora_A"])
+        V_hat = V / (np.linalg.norm(V, axis=norm_dim, keepdims=True) + 1e-12)
+        return V_hat * _mag_2d(p["magnitude"], norm_dim)
+
+    if adapter_type == "bora":
+        V = W0 + scaling * (p["lora_B"] @ p["lora_A"])
+        V_r = V / (np.linalg.norm(V, axis=1, keepdims=True) + 1e-12)
+        inter = p["magnitude_r"].reshape(-1, 1) * V_r
+        H_c = inter / (np.linalg.norm(inter, axis=0, keepdims=True) + 1e-12)
+        return H_c * p["magnitude_c"].reshape(1, -1)
+
+    if adapter_type.endswith("-xs"):
+        rank = p["M_xs"].shape[0]
+        U, V = _svd_bases(W0, rank)
+        Vfull = W0 + scaling * (U @ p["M_xs"] @ V.T)
+        if adapter_type == "lora-xs":
+            return Vfull
+        if adapter_type in ("dora-rows-xs", "dora-cols-xs"):
+            norm_dim = 1 if adapter_type == "dora-rows-xs" else 0
+            V_hat = Vfull / (np.linalg.norm(Vfull, axis=norm_dim, keepdims=True) + 1e-12)
+            return V_hat * _mag_2d(p["magnitude"], norm_dim)
+        if adapter_type == "bora-xs":
+            V_r = Vfull / (np.linalg.norm(Vfull, axis=1, keepdims=True) + 1e-12)
+            inter = p["magnitude_r"].reshape(-1, 1) * V_r
+            H_c = inter / (np.linalg.norm(inter, axis=0, keepdims=True) + 1e-12)
+            return H_c * p["magnitude_c"].reshape(1, -1)
+
+    raise LoraError(f"unknown adapter_type {adapter_type!r}")
+
+
+def check_shapes(layer: str, W0: np.ndarray, p: dict, adapter_type: str) -> None:
+    """Clear error when the adapter doesn't fit the base weight — almost always a
+    wrong-base-model mismatch. Without it the failure is a raw numpy broadcast."""
+    fan_out, fan_in = W0.shape
+    if adapter_type.endswith("-xs"):
+        rank = p["M_xs"].shape[0]
+        if rank > min(fan_out, fan_in):
+            raise LoraError(
+                f"{layer}: LoRA-XS rank {rank} exceeds base min-dim "
+                f"{min(fan_out, fan_in)} for weight {W0.shape} — wrong base model?"
+            )
+        return
+    b_out, b_rank = p["lora_B"].shape
+    a_rank, a_in = p["lora_A"].shape
+    if b_out != fan_out or a_in != fan_in or a_rank != b_rank:
+        raise LoraError(
+            f"{layer}: adapter lora_B{p['lora_B'].shape}·lora_A{p['lora_A'].shape} "
+            f"does not fit base weight {W0.shape} — wrong base model?"
+        )
+
+
+# ── checkpoint parsing → normalized per-layer adapter ──────────────────────────
+
+def _resolve_path(path: str) -> str:
+    """Accept a .safetensors file or a PEFT adapter directory (resolve to the
+    adapter_model.safetensors inside it)."""
+    if os.path.isdir(path):
+        cand = os.path.join(path, "adapter_model.safetensors")
+        if os.path.isfile(cand):
+            return cand
+        hits = [f for f in os.listdir(path) if f.lower().endswith(".safetensors")]
+        if len(hits) == 1:
+            return os.path.join(path, hits[0])
+        raise LoraError(
+            f"{path!r}: expected one .safetensors adapter in the directory, found {hits}"
+        )
+    return path
+
+
+def parse_adapter(path: str):
+    """Load one adapter → ``(adapter_type, scaling, layers)`` where ``layers``
+    maps a checkpoint layer name → its param dict (numpy float32)."""
+    tensors, meta = _load_safetensors(path)
+
+    native_marker = ".parametrizations.weight.0."
+    if any(native_marker in k for k in tensors):
+        cfg = json.loads(meta.get("lora_config", "{}")) if meta else {}
+        layers = _group_native(tensors)
+        rank = int(cfg.get("rank") or _infer_rank(layers))
+        alpha = float(cfg.get("alpha", rank))
+        adapter_type = _resolve_native_type(cfg.get("adapter_type", "lora"))
+        return adapter_type, alpha / rank, layers
+
+    peft_marker = ".lora_A.weight"
+    if any(k.endswith(peft_marker) for k in tensors):
+        cfg = _read_peft_config(path)
+        rank = int(cfg["r"])
+        alpha = float(cfg.get("lora_alpha", rank))
+        use_dora = bool(cfg.get("use_dora", False))
+        use_rslora = bool(cfg.get("use_rslora", False))
+        adapter_type = "dora-rows" if use_dora else "lora"
+        scaling = alpha / (np.sqrt(rank) if use_rslora else rank)
+        return adapter_type, scaling, _group_peft(tensors)
+
+    raise LoraError(
+        f"{os.path.basename(path)!r}: not a recognised LoRA (no SA3-native "
+        f"parametrization keys and no PEFT lora_A/lora_B keys)"
+    )
+
+
+def _group_native(tensors: dict) -> dict:
+    marker = ".parametrizations.weight.0."
+    layers: dict[str, dict] = {}
+    for k, v in tensors.items():
+        if marker not in k:
+            continue
+        layer, _, param = k.partition(marker)
+        layers.setdefault(layer, {})[param] = v
+    return layers
+
+
+def _group_peft(tensors: dict) -> dict:
+    prefix = "base_model.model."
+    layers: dict[str, dict] = {}
+    for k, v in tensors.items():
+        name = k[len(prefix):] if k.startswith(prefix) else k
+        for suffix, param in ((".lora_A.weight", "lora_A"),
+                              (".lora_B.weight", "lora_B"),
+                              (".lora_magnitude_vector.weight", "magnitude")):
+            if name.endswith(suffix):
+                layers.setdefault(name[: -len(suffix)], {})[param] = v
+                break
+    return layers
+
+
+def _read_peft_config(path: str) -> dict:
+    cfg_path = os.path.join(os.path.dirname(path), "adapter_config.json")
+    if not os.path.isfile(cfg_path):
+        raise LoraError(f"PEFT adapter at {path!r} is missing its adapter_config.json sibling")
+    with open(cfg_path) as fh:
+        return json.load(fh)
+
+
+def _infer_rank(layers: dict) -> int:
+    for params in layers.values():
+        if "lora_A" in params:
+            return params["lora_A"].shape[0]
+        if "M_xs" in params:
+            return params["M_xs"].shape[0]
+    raise LoraError("cannot infer LoRA rank (no lora_A / M_xs tensors)")
+
+
+def _resolve_native_type(adapter_type: str) -> str:
+    """Legacy 'dora' → 'dora-rows' (mirrors utils.resolve_adapter_type)."""
+    return "dora-rows" if adapter_type == "dora" else adapter_type
+
+
+# ── CLI spec parsing ────────────────────────────────────────────────────────
+
+def parse_lora_spec(tokens, default_strength: float = 1.0) -> dict:
+    """Parse one ``--lora`` group: ``PATH [strength=S]``.
+
+    Mirrors the MLX CLI's flag, minus ``steps=`` — per-step LoRA gating is not
+    feasible on a frozen TFLite graph (weights are packed into XNNPACK's private
+    buffers at allocate_tensors; there is no per-step re-merge), so ``steps=`` is
+    rejected with a pointer to the MLX backend.
+    """
+    if not tokens:
+        raise LoraError("--lora needs an adapter path")
+    spec = {"path": tokens[0], "strength": float(default_strength)}
+    for tok in tokens[1:]:
+        key, eq, val = tok.partition("=")
+        if key == "steps":
+            raise LoraError(
+                "--lora steps=… (per-step gating) is not supported on the TFLite "
+                "backend — the frozen graph's weights are merged once at load. "
+                "Use the MLX backend (optimized/mlx) for step-gated LoRA."
+            )
+        if not eq or key != "strength":
+            raise LoraError(
+                f"--lora: unexpected token {tok!r} — one adapter per --lora flag; "
+                f"the only option after the path is strength=S "
+                f"(e.g. --lora a.safetensors strength=0.8)"
+            )
+        try:
+            spec["strength"] = float(val)
+        except ValueError:
+            raise LoraError(f"--lora: bad strength {val!r}") from None
+    return spec

--- a/optimized/tflite/scripts/lora_patch.py
+++ b/optimized/tflite/scripts/lora_patch.py
@@ -1,0 +1,389 @@
+"""Merge LoRA adapters into a baked SA3 DiT ``.tflite`` by patching its weight
+buffers — the TFLite counterpart of the MLX weight-dict merge.
+
+A ``.tflite`` is a frozen FlatBuffer: there is no weight dict to edit at load, so
+LoRA inference means rewriting the FULLY_CONNECTED weight buffers in place. The
+mechanism (validated on the 5.8 GB medium DiT):
+
+  1. Parse the FlatBuffer header (mmap, no full read) and map every
+     checkpoint layer name → the file offset/size/dtype of its FC weight buffer.
+  2. Clone the base file (APFS ``cp -c`` = a few ms and no extra disk until
+     written; plain copy elsewhere).
+  3. For each adapter layer: read W0 from the clone's mmap, compute W' with the
+     shared numpy merge math (``lora_core.merged_weight``), and overwrite the
+     buffer's bytes at its exact offset. Deltas from multiple adapters accumulate
+     against the ORIGINAL W0 (order-independent), matching the MLX path.
+
+Patching happens BEFORE ``Interpreter(...)`` so XNNPACK packs the merged weights
+at ``allocate_tensors`` exactly as for an unpatched model — no runtime cost, no
+cache interaction. Patched files are cached by a content hash of (base, adapters,
+strengths), so repeat runs reuse them instantly.
+
+Precision: fp32 (weights are direct fp32 consts) and w16a32 (weights are fp16
+consts behind a DEQUANTIZE) are supported. Quantized-int8 variants (w8a32,
+w8a8-dyn, w4a32) are refused — merging requires a dequant→merge→requant that
+sacrifices the GPTQ error-feedback grid (a phase-2 item).
+
+Name mapping tiers (all hard-fail on ambiguity — never silently mis-patch):
+  1. Block linears (self_attn/cross_attn/ff): name carries ``TransformerBlock_N``
+     → (block, module, leaf) + shape → unique.
+  2. ``to_local_embed.seq.{0,2}``: per-block but the tflite names carry NO block
+     index and their ``;NN`` counter runs BACKWARDS — block identity comes from
+     FC topological order within the group, never the counter.
+  3. Prefix embedders / project_in / project_out: singleton names → unique.
+  4. Seconds conditioner: the unique ``(768, 256)`` FC (in-graph, patchable).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import mmap
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lora_core as lc  # noqa: E402
+
+# Bump when the merge math or mapping changes so stale cache entries are missed.
+_MERGE_VERSION = "1"
+
+_QUANTIZED_PRECISIONS = ("w8a32", "w8a8-dyn", "w4a32")
+
+
+# ── FlatBuffer FC-weight discovery ─────────────────────────────────────────────
+
+def _fc_weight_buffers(buf):
+    """Yield one record per FULLY_CONNECTED weight, in graph topological order:
+    ``dict(name, shape, off, size, np_dtype, op_index)``.
+
+    Resolves the weight buffer through a DEQUANTIZE (w16a32: fp16 const) or takes
+    the FC's weight input directly (fp32: fp32 const). Refuses int8 weights.
+    """
+    from ai_edge_litert import schema_py_generated as schema
+    BO = schema.BuiltinOperator
+    TT = schema.TensorType
+    _NP = {TT.FLOAT32: np.float32, TT.FLOAT16: np.float16}
+
+    m = schema.Model.GetRootAs(buf, 0)
+    sg = m.Subgraphs(0)
+    producer = {}
+    for oi in range(sg.OperatorsLength()):
+        op = sg.Operators(oi)
+        bc = m.OperatorCodes(op.OpcodeIndex()).BuiltinCode()
+        for j in range(op.OutputsLength()):
+            producer[op.Outputs(j)] = (bc, op)
+
+    for oi in range(sg.OperatorsLength()):
+        op = sg.Operators(oi)
+        if m.OperatorCodes(op.OpcodeIndex()).BuiltinCode() != BO.FULLY_CONNECTED:
+            continue
+        w_idx = op.Inputs(1)
+        wt = sg.Tensors(w_idx)
+        shape = tuple(wt.Shape(i) for i in range(wt.ShapeLength()))
+        name = (wt.Name() or b"?").decode()
+        prod = producer.get(w_idx)
+        if prod is not None and prod[0] == BO.DEQUANTIZE:
+            # w16a32: FC weight ← DEQUANTIZE ← fp16 const (the patch target).
+            src = sg.Tensors(prod[1].Inputs(0))
+            ttype = src.Type()
+            b = m.Buffers(src.Buffer())
+            src_name = (src.Name() or wt.Name() or b"?").decode()
+        else:
+            ttype, b, src_name = wt.Type(), m.Buffers(wt.Buffer()), name
+        if ttype not in _NP:
+            raise lc.LoraError(
+                f"FC weight {name!r} is {TT.__dict__ and _tt_name(ttype)} — LoRA merge "
+                f"on the TFLite backend supports fp32 and w16a32 (fp16) weights only. "
+                f"Quantized-int8 models (w8a32 / w8a8-dyn / w4a32) are not supported "
+                f"(merging would destroy the GPTQ grid). Use --precision fp32 or w16a32."
+            )
+        off, size = b.Offset(), b.Size()
+        if off == 0 or size == 0:
+            raise lc.LoraError(
+                f"FC weight {name!r} is not stored in an out-of-band buffer "
+                f"(off={off}, size={size}) — cannot patch in place."
+            )
+        yield dict(name=name, dbg=src_name, shape=shape, off=off, size=size,
+                   np_dtype=_NP[ttype], op_index=oi)
+
+
+def _tt_name(code):
+    from ai_edge_litert import schema_py_generated as schema
+    return next((k for k, v in schema.TensorType.__dict__.items() if v == code), str(code))
+
+
+# ── name classification → checkpoint-layer resolution ──────────────────────────
+
+_LEAF = re.compile(r"torch\.nn\.modules\.linear\.Linear_([A-Za-z0-9_]+)")
+_BLOCK = re.compile(r"TransformerBlock_(\d+)/")
+
+# checkpoint (post model.-strip) block-module suffix → (module tag, tflite leaf, glu)
+_BLOCK_CKPT = {
+    "self_attn.to_qkv": ("self_attn", "to_qkv", False),
+    "self_attn.to_out": ("self_attn", "to_out", False),
+    "cross_attn.to_q": ("cross_attn", "to_q", False),
+    "cross_attn.to_kv": ("cross_attn", "to_kv", False),
+    "cross_attn.to_out": ("cross_attn", "to_out", False),
+    "ff.ff.0.proj": ("ff", "proj", True),
+    "ff.ff.2": ("ff", "2", False),
+    # to_local_embed handled separately (topological order); accept both the
+    # torch (.0/.2) and MLX (.seq.0/.seq.2) spellings.
+    "to_local_embed.0": ("local_embed", "0", False),
+    "to_local_embed.2": ("local_embed", "2", False),
+    "to_local_embed.seq.0": ("local_embed", "0", False),
+    "to_local_embed.seq.2": ("local_embed", "2", False),
+}
+
+# non-block singleton checkpoint names → a substring that uniquely identifies the
+# tflite FC name (verified against the exported graph).
+_SINGLETON_CKPT = {
+    "transformer.project_in": "Linear_project_in",
+    "transformer.project_out": "Linear_project_out",
+    "to_timestep_embed.0": "Sequential_to_timestep_embed/torch.nn.modules.linear.Linear_0",
+    "to_timestep_embed.2": "Sequential_to_timestep_embed/torch.nn.modules.linear.Linear_2",
+    "to_cond_embed.0": "Sequential_to_cond_embed/torch.nn.modules.linear.Linear_0",
+    "to_cond_embed.2": "Sequential_to_cond_embed/torch.nn.modules.linear.Linear_2",
+    "to_global_embed.0": "Sequential_to_global_embed/torch.nn.modules.linear.Linear_0",
+    "to_global_embed.2": "Sequential_to_global_embed/torch.nn.modules.linear.Linear_2",
+    "transformer.global_cond_embedder.0": "Sequential_global_cond_embedder/torch.nn.modules.linear.Linear_0",
+    "transformer.global_cond_embedder.2": "Sequential_global_cond_embedder/torch.nn.modules.linear.Linear_2",
+}
+
+
+def _module_tag(name: str) -> str | None:
+    if "SelfAttention_self_attn" in name:
+        return "self_attn"
+    if "CrossAttention_cross_attn" in name:
+        return "cross_attn"
+    if "Seq_to_local_embed" in name or "Sequential_seq" in name:
+        return "local_embed"
+    if "FeedForward_ff" in name:
+        return "ff"
+    return None
+
+
+class _Mapper:
+    """Resolves checkpoint layer names → FC weight records for one base model."""
+
+    def __init__(self, fcs):
+        self._fcs = fcs
+        # tier-1 block linears: (block, module, leaf, glu) → record
+        self._block = {}
+        # tier-2 local_embed: leaf ('0'/'2') → [records in topological order]
+        self._local = {"0": [], "2": []}
+        self._seconds = []  # tier-4
+        for rec in fcs:  # fcs already in topological (op) order
+            name = rec["name"]
+            mod = _module_tag(name)
+            mleaf = _LEAF.search(name)
+            leaf = mleaf.group(1) if mleaf else None
+            mblk = _BLOCK.search(name)
+            if mod == "local_embed" and leaf in ("0", "2"):
+                self._local[leaf].append(rec)
+            elif mod in ("self_attn", "cross_attn", "ff") and mblk and leaf:
+                glu = "_GLUWrap_0" in name
+                self._block[(int(mblk.group(1)), mod, leaf, glu)] = rec
+            if rec["shape"] == (768, 256):
+                self._seconds.append(rec)
+
+    def resolve(self, layer: str, want_shape):
+        """Return the FC record for a checkpoint layer, or raise LoraError."""
+        if layer == lc.COND_SECONDS_LAYER:
+            cands = [r for r in self._seconds if r["shape"] == want_shape]
+            return self._one(layer, want_shape, cands, "seconds conditioner")
+
+        stripped = layer[len("model."):] if layer.startswith("model.") else layer
+        mm = re.match(r"transformer\.layers\.(\d+)\.(.+)$", stripped)
+        if mm:
+            block, suffix = int(mm.group(1)), mm.group(2)
+            spec = _BLOCK_CKPT.get(suffix)
+            if spec is None:
+                raise lc.LoraError(f"{layer}: unrecognised block sub-module {suffix!r}")
+            module, leaf, glu = spec
+            if module == "local_embed":
+                # tier 2 — topological rank within the group is the block index.
+                group = self._local[leaf]
+                if block >= len(group):
+                    raise lc.LoraError(
+                        f"{layer}: to_local_embed block {block} out of range "
+                        f"(only {len(group)} in the graph)")
+                rec = group[block]
+                if rec["shape"] != tuple(want_shape):
+                    raise lc.LoraError(
+                        f"{layer}: shape {rec['shape']} != adapter {tuple(want_shape)} "
+                        f"— wrong base model?")
+                return rec
+            rec = self._block.get((block, module, leaf, glu))
+            cands = [rec] if rec is not None and rec["shape"] == tuple(want_shape) else []
+            return self._one(layer, want_shape, cands, "block linear")
+
+        sub = _SINGLETON_CKPT.get(stripped)
+        if sub is None:
+            raise lc.LoraError(f"{layer}: no TFLite tensor mapping for this layer")
+        cands = [r for r in self._fcs if sub in r["name"] and r["shape"] == tuple(want_shape)]
+        return self._one(layer, want_shape, cands, "singleton")
+
+    @staticmethod
+    def _one(layer, want_shape, cands, tier):
+        if len(cands) == 1:
+            return cands[0]
+        raise lc.LoraError(
+            f"{layer}: expected exactly 1 matching FC ({tier}, shape {tuple(want_shape)}), "
+            f"found {len(cands)} — wrong base model or unsupported target module?"
+        )
+
+
+# ── clone + patch + cache ──────────────────────────────────────────────────────
+
+def _clone(src: str, dst: str) -> None:
+    """COW-clone src→dst (APFS ``cp -c``, instant) or fall back to a full copy."""
+    try:
+        r = subprocess.run(["cp", "-c", src, dst], capture_output=True)
+        if r.returncode == 0 and os.path.exists(dst):
+            return
+    except (OSError, FileNotFoundError):
+        pass
+    shutil.copyfile(src, dst)
+
+
+def _cache_key(base_path: str, specs) -> str:
+    h = hashlib.sha256()
+    h.update(_MERGE_VERSION.encode())
+    st = os.stat(base_path)
+    h.update(f"{os.path.basename(base_path)}:{st.st_size}".encode())
+    for path, strength in sorted((lc._resolve_path(s["path"]), s["strength"]) for s in specs):
+        fh = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                fh.update(chunk)
+        h.update(f"{fh.hexdigest()}:{strength}".encode())
+    return h.hexdigest()[:12]
+
+
+def get_patched_dit(base_path, specs, *, family: str, precision: str,
+                    cache_dir=None, log=print) -> Path:
+    """Return a path to a DiT ``.tflite`` with ``specs`` (from
+    :func:`lora_core.parse_lora_spec`) merged into its weights. Result is cached
+    by content hash; a hit returns instantly. Raises LoraError on any mapping,
+    shape, precision, or trust-boundary failure — never mis-patches silently.
+    """
+    base_path = str(base_path)
+    if precision in _QUANTIZED_PRECISIONS:
+        raise lc.LoraError(
+            f"--lora is not supported with --precision {precision} (quantized-int8) — "
+            f"merging int8 weights would destroy the GPTQ grid. Use fp32 or w16a32."
+        )
+
+    cache_dir = Path(cache_dir or (Path(base_path).resolve().parents[2] / "lora_cache"))
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    key = _cache_key(base_path, specs)
+    out = cache_dir / f"dit_{family}_{precision}_{key}.tflite"
+    if out.exists():
+        log(f"lora: reusing cached patched model {out.name}")
+        return out
+
+    # Parse all adapters up front (fail fast before the clone).
+    parsed = []
+    for s in specs:
+        path = lc._resolve_path(s["path"])
+        adapter_type, scaling, layers = lc.parse_adapter(path)
+        parsed.append((os.path.basename(path), adapter_type, scaling,
+                       float(s["strength"]), layers))
+        log(f"lora: {os.path.basename(path)} — {adapter_type}, "
+            f"scaling {scaling:g}, strength {s['strength']:g}, {len(layers)} layers")
+
+    # Map every adapter layer against the base model BEFORE cloning (so a
+    # wrong-base adapter errors without leaving a stale clone behind).
+    with open(base_path, "rb") as f:
+        buf = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+        fcs = list(_fc_weight_buffers(buf))
+        mapper = _Mapper(fcs)
+        # accum[off] = [record, W0(fp32), summed_delta(fp32)]
+        accum = {}
+        matched = 0
+        for name, atype, scaling, strength, layers in parsed:
+            need = lc._PARAMS_FOR.get(atype, ())
+            for layer, params in layers.items():
+                want = (params.get("lora_B", params.get("M_xs")).shape[0],
+                        params["lora_A"].shape[1] if "lora_A" in params
+                        else params["M_xs"].shape[1])
+                # For -xs, fan_in comes from the base weight; resolve then re-check.
+                rec = mapper.resolve(layer, want if atype not in
+                                     ("lora-xs", "dora-rows-xs", "dora-cols-xs", "bora-xs")
+                                     else _shape_from_leaf(mapper, layer, params))
+                W0 = np.frombuffer(buf, rec["np_dtype"],
+                                   count=rec["size"] // np.dtype(rec["np_dtype"]).itemsize,
+                                   offset=rec["off"]).reshape(rec["shape"]).astype(np.float32)
+                missing = [n for n in need if n not in params]
+                if missing:
+                    raise lc.LoraError(f"{layer}: adapter is {atype} but missing {missing}")
+                lc.check_shapes(layer, W0, params, atype)
+                merged = lc.merged_weight(W0, params, atype, scaling)
+                delta = strength * (merged - W0)
+                if rec["off"] in accum:
+                    accum[rec["off"]][2] += delta
+                else:
+                    accum[rec["off"]] = [rec, W0, delta]
+                matched += 1
+        buf.close()
+    if not matched:
+        raise lc.LoraError("no adapter layers matched this DiT (wrong base model?)")
+    log(f"lora: mapped {len(accum)} weight tensor(s) across {matched} adapter layer(s)")
+
+    # Clone, then patch each buffer once (W0 + summed delta).
+    tmp = out.with_suffix(".tflite.tmp")
+    if tmp.exists():
+        tmp.unlink()
+    _clone(base_path, str(tmp))
+    n_bytes = 0
+    with open(tmp, "r+b") as fw:
+        for off, (rec, W0, delta) in accum.items():
+            Wp = (W0 + delta).astype(rec["np_dtype"])
+            b = Wp.tobytes()
+            assert len(b) == rec["size"], (rec["name"], len(b), rec["size"])
+            fw.seek(off)
+            fw.write(b)
+            n_bytes += rec["size"]
+        fw.flush()
+        os.fsync(fw.fileno())
+    os.replace(tmp, out)
+    log(f"lora: patched {n_bytes / 1e6:.0f} MB → {out.name}")
+    return out
+
+
+def _shape_from_leaf(mapper: _Mapper, layer: str, params: dict):
+    """For -xs adapters the fan_in isn't in the params (only M_xs r×r), so map by
+    a shape probe: try each FC whose descriptor matches and return its shape.
+    Resolves by re-using the mapper's block/singleton/seconds index with a
+    wildcard shape, then reads the found record's shape."""
+    # Cheap approach: the -xs magnitude (rows/cols) or M_xs can't give fan_in, so
+    # locate the record ignoring shape via a temporary relaxation.
+    stripped = layer[len("model."):] if layer.startswith("model.") else layer
+    if layer == lc.COND_SECONDS_LAYER and mapper._seconds:
+        return mapper._seconds[0]["shape"]
+    mm = re.match(r"transformer\.layers\.(\d+)\.(.+)$", stripped)
+    if mm:
+        block, suffix = int(mm.group(1)), mm.group(2)
+        spec = _BLOCK_CKPT.get(suffix)
+        if spec:
+            module, leaf, glu = spec
+            if module == "local_embed":
+                grp = mapper._local[leaf]
+                if block < len(grp):
+                    return grp[block]["shape"]
+            else:
+                rec = mapper._block.get((block, module, leaf, glu))
+                if rec:
+                    return rec["shape"]
+    sub = _SINGLETON_CKPT.get(stripped)
+    if sub:
+        for r in mapper._fcs:
+            if sub in r["name"]:
+                return r["shape"]
+    raise lc.LoraError(f"{layer}: cannot locate a base weight for this -xs layer")

--- a/optimized/tflite/scripts/lora_patch.py
+++ b/optimized/tflite/scripts/lora_patch.py
@@ -280,7 +280,10 @@ def get_patched_dit(base_path, specs, *, family: str, precision: str,
             f"merging int8 weights would destroy the GPTQ grid. Use fp32 or w16a32."
         )
 
-    cache_dir = Path(cache_dir or (Path(base_path).resolve().parents[2] / "lora_cache"))
+    # Cache next to the family dirs (models/tflite/lora_cache/) — use the
+    # base's OWN path, not resolve(): the base is usually a symlink into the HF
+    # cache, and resolving it would drop the patched (multi-GB) clones there.
+    cache_dir = Path(cache_dir or (Path(base_path).parent.parent / "lora_cache"))
     cache_dir.mkdir(parents=True, exist_ok=True)
     key = _cache_key(base_path, specs)
     out = cache_dir / f"dit_{family}_{precision}_{key}.tflite"

--- a/optimized/tflite/scripts/sa3_gradio.py
+++ b/optimized/tflite/scripts/sa3_gradio.py
@@ -1,0 +1,1298 @@
+"""SA3 TFLite — gradio web UI (portable CPU / XNNPACK).
+
+The TFLite sibling of optimized/mlx/scripts/sa3_gradio.py, driving the baked-I/O
+varlen TFLite models (scripts/sa3_tflite.py) instead of MLX. Every generation mode
+is wired, plus a precision picker the MLX/TRT UIs don't need:
+  - Model picker: sm-music / sm-sfx / medium (hot-swap; the large DiT interpreter
+    is cached — first use of a model/precision/length loads + XNNPACK-packs the
+    weights, subsequent runs reuse it and only re-bind the conditioning).
+  - Precision picker: fp32 / w16a32 / w8a32 / w8a8-dyn (one knob for DiT + codec +
+    encoder, exactly like the CLI's --precision). fp32 is the CPU fast-and-accurate
+    default; w16a32 is ≈lossless half-size; w8a32/w8a8-dyn are GPTQ int8 (¼ size).
+  - CFG 0-10 next to seconds/steps (0 = negative prompt takes over, 0.5 = halfway
+    between prompts, 1 = off, >1 = extrapolate) + negative prompt/APG under Advanced.
+  - Audio-to-audio: guide audio + init_noise_level (whole clip starts from its
+    latents); global sigma_max under Advanced for prompt-only generations.
+  - Inpainting: separate reference audio + start/end range sliders (kept bit-exact
+    outside the range). Combinable with a2a.
+  - LoRA: file upload + local-folder pick (loras/<model>/) + strength, per-model
+    memory, add/remove. Merged once into the DiT weights at load (the frozen graph
+    has no per-step gating — so no Min/Max-step sliders, unlike the MLX UI). Only
+    fp32 / w16a32 can be LoRA-merged; the panel disables itself under int8.
+  - Spectrogram-as-player (numpy port, white playhead, click-to-seek), history
+    panel, Output options (Auto-play / Auto-download / Infinite Radio / Loop /
+    Hotswap), MP3 (via ffmpeg) or WAV saving.
+
+Launch:
+    ./sa3-gradio                  # share=True by default, sm-music + same-s, fp32
+    ./sa3-gradio --dit medium --precision w8a32
+    ./sa3-gradio --no-share       # local-only
+"""
+from __future__ import annotations
+import argparse
+import base64
+import gc
+import html as html_lib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.parse
+import wave
+from pathlib import Path
+
+import numpy as np
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO = SCRIPTS_DIR.parent
+sys.path.insert(0, str(REPO))          # so `from models.defs.* import` resolves
+sys.path.insert(0, str(SCRIPTS_DIR))   # so `from weights / lora_* / spec import` resolves
+
+from sa3_tflite import (  # noqa: E402
+    BakedDiT, BakedEncoder, BakedDecoder, read_wav,
+    valid_T_lat, DEFAULT_DECODER, DIT_REL, DEC_REL, T5_REL,
+    COND_TOKENS, COND_DIM, SAMPLE_RATE, SAMPLES_PER_LATENT,
+    SAMEL_CHUNK, SAMEL_OVERLAP, MIN_SIGMA,
+)
+from models.defs import tflite_pipeline as P   # noqa: E402
+from lora_core import parse_lora_spec, LoraError  # noqa: E402
+from lora_patch import get_patched_dit  # noqa: E402
+from weights import ensure_local, PRECISIONS, dit_rel, dec_rel, enc_rel  # noqa: E402
+from spec import render_spectrogram_png  # noqa: E402
+
+OUTPUT_DIR = REPO / "output" / "gradio"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+# Local LoRA library: drop .safetensors under loras/<model>/ and they appear in
+# the per-slot dropdown (scanned per selected DiT; hidden when empty).
+LORAS_DIR = REPO / "loras"
+LORA_DIR_NAMES = {"medium": "sa3-medium", "sm-sfx": "sa3-sm-sfx",
+                  "sm-music": "sa3-sm-music"}
+for _d in LORA_DIR_NAMES.values():
+    (LORAS_DIR / _d).mkdir(parents=True, exist_ok=True)
+_DD_NONE = ""   # dropdown placeholder value ("--- Choose a LoRA ---")
+
+# Precisions whose weights can be LoRA-merged (fp32 consts + w16a32 fp16-behind-
+# DEQUANTIZE). Quantized-int8 graphs (w8a32 / w8a8-dyn) can't — see lora_patch.
+LORA_PRECISIONS = ("fp32", "w16a32")
+# Trained max clip length per model (repo README model table).
+MAX_SECONDS = {"sm-music": 120, "sm-sfx": 120, "medium": 380}
+DEFAULT_DECODERS = dict(DEFAULT_DECODER)
+# XNNPACK CPU threads (set from --threads in main()).
+_THREADS = 8
+
+
+def _lora_dd_choices(dit_name: str) -> list:
+    """Dropdown choices for ./loras/<model>/: placeholder + (name, abspath)."""
+    d = LORAS_DIR / LORA_DIR_NAMES.get(dit_name, dit_name)
+    hits = sorted(d.glob("*.safetensors")) if d.is_dir() else []
+    return [("--- Choose a LoRA ---", _DD_NONE)] + [(p.name, str(p)) for p in hits]
+
+
+# MP3 (V0) saving needs ffmpeg; without it we save WAV and hide the choice.
+FFMPEG = shutil.which("ffmpeg") is not None
+FORMAT_MP3, FORMAT_WAV = "Save to MP3 (V0)", "Save to WAV"
+
+# The baked TFLite models are frozen FlatBuffer graphs, so unlike MLX there is no
+# ThreadLocalStream hazard — but a single XNNPACK Interpreter must NOT be invoked
+# from two threads at once, and gradio runs each handler on a rotating anyio worker
+# thread. The categorical fix (same structure as the MLX UI): ALL model work
+# (pre-warm + every generation) runs on one dedicated owner thread; handlers submit
+# to it and wait. This also serializes generations.
+import concurrent.futures as _cf  # noqa: E402
+_EXECUTOR = _cf.ThreadPoolExecutor(max_workers=1, thread_name_prefix="tfl")
+
+
+def run_serial(fn, *args, **kwargs):
+    """Run fn on the owner thread and return its result (re-raises errors)."""
+    return _EXECUTOR.submit(fn, *args, **kwargs).result()
+
+
+def read_audio_any(path: str) -> np.ndarray:
+    """(2, T) float32 @ 44.1 kHz from any common upload format.
+
+    Layered: read_wav handles 16-bit/44.1k natively and shells out to ffmpeg
+    for the rest when installed; if that fails (no ffmpeg), soundfile's bundled
+    libsndfile decodes mp3/flac/ogg/24-bit/48 kHz directly, followed by a
+    linear resample to 44.1 kHz."""
+    try:
+        return read_wav(path)
+    except Exception:
+        import soundfile as sf
+        data, sr = sf.read(path, dtype="float32", always_2d=True)   # (T, ch)
+        y = data.T
+        y = np.stack([y[0], y[0]]) if y.shape[0] == 1 else y[:2]
+        if sr != SAMPLE_RATE:
+            in_len = y.shape[-1]
+            new_len = int(round(in_len * SAMPLE_RATE / sr))
+            scale = in_len / new_len
+            pos = np.clip((np.arange(new_len) + 0.5) * scale - 0.5, 0, in_len - 1)
+            y = np.stack([np.interp(pos, np.arange(in_len), ch) for ch in y])
+        return np.ascontiguousarray(y, dtype=np.float32)
+
+
+def condense_prompt(prompt: str) -> str:
+    """Prompt → filename fragment (the main repo's verbose-naming rule):
+    filesystem-special characters become hyphens, capped at 150 chars."""
+    prompt = re.sub(r'[\\/:*?"<>|]', '-', prompt)[:150]
+    return prompt or "_"
+
+
+def verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed, precision) -> str:
+    """prompt[.neg-…][.cfg{scale}][.smx{σ}][.{precision}].{seed} — the main repo's
+    gradio 'verbose' file naming, plus a precision tag for non-fp32 runs so A/B
+    runs across --precision don't overwrite each other."""
+    base = condense_prompt(prompt)
+    if negative_prompt and negative_prompt.strip():
+        base += ".neg-" + condense_prompt(negative_prompt.strip())
+    if cfg != 1.0:
+        base += f".cfg{cfg:g}"
+    if sigma_max != 1.0:
+        base += f".smx{sigma_max:g}"
+    if precision and precision != "fp32":
+        base += f".{precision}"
+    return f"{base}.{seed}"
+
+
+def _save_wav(pcm_int16, out_path):
+    """pcm_int16: (T, 2) int16 interleaved."""
+    with wave.open(str(out_path), "wb") as w:
+        w.setnchannels(2)
+        w.setsampwidth(2)
+        w.setframerate(SAMPLE_RATE)
+        w.writeframes(pcm_int16.tobytes())
+
+
+# ── Model caches ─────────────────────────────────────────────────────────────
+# The T5Gemma front-end is loaded once (fixed 256 tokens). The DiT interpreter is
+# large (medium fp32 ≈ 5.8 GB) and holds its conditioning as RESIDENT tensors, so
+# it's cached by FILE PATH (dit family + precision, or the LoRA-patched clone) and
+# re-bound per generation via set_conditioning — resize+allocate only when the
+# batch (cfg) or length changes. Codec enc/dec are cached by (name, precision).
+_t5 = None
+_tok = None
+_dit_cache: dict[str, BakedDiT] = {}
+_dit_lru: list[str] = []
+_DIT_CACHE_MAX = 1          # one big DiT resident at a time (medium fp32 = 5.8 GB)
+_dec_cache: dict[tuple, BakedDecoder] = {}
+_dec_lru: list[tuple] = []
+_enc_cache: dict[tuple, BakedEncoder] = {}
+_enc_lru: list[tuple] = []
+_CODEC_CACHE_MAX = 2
+# Encoded-latent cache: rerunning a2a/inpainting with the same input audio skips
+# the encoder. Keyed on the file's CONTENT hash (gradio re-uploads get fresh temp
+# paths) + codec + precision + latent length.
+_latent_cache: dict[tuple, np.ndarray] = {}
+_LATENT_CACHE_MAX = 32
+
+
+def get_t5():
+    global _t5, _tok
+    if _t5 is None:
+        _t5 = P.T5GemmaTFLite(ensure_local(T5_REL), _THREADS)
+        _tok = P.Tokenizer()
+    return _t5, _tok
+
+
+def get_dit(dit_path, T_lat, t5_hidden, t5_mask, seconds, cfg, apg,
+            null_h, null_m, local_add_cond, batched):
+    """Cache the (large) baked DiT interpreter by its file path; re-bind the
+    per-generation conditioning via set_conditioning. Returns (model, load_ms)."""
+    key = str(dit_path)
+    if key in _dit_cache:
+        if key in _dit_lru:
+            _dit_lru.remove(key)
+        _dit_lru.append(key)
+        model = _dit_cache[key]
+        model.set_conditioning(T_lat, t5_hidden, t5_mask, seconds, cfg=cfg, apg=apg,
+                               null_hidden=null_h, null_mask=null_m,
+                               local_add_cond=local_add_cond, batched=batched)
+        return model, 0.0
+    while len(_dit_cache) >= _DIT_CACHE_MAX:
+        old = _dit_lru.pop(0)
+        print(f"  ← LRU-evicting DiT {Path(old).name}")
+        _dit_cache.pop(old, None)
+        gc.collect()
+    t0 = time.time()
+    model = BakedDiT(dit_path, T_lat, t5_hidden, t5_mask, seconds, _THREADS,
+                     cfg=cfg, apg=apg, null_hidden=null_h, null_mask=null_m,
+                     local_add_cond=local_add_cond, batched=batched)
+    load_ms = (time.time() - t0) * 1000
+    _dit_cache[key] = model
+    _dit_lru.append(key)
+    return model, load_ms
+
+
+def get_decoder(name: str, precision: str) -> BakedDecoder:
+    key = (name, precision)
+    if key in _dec_cache:
+        _dec_lru.remove(key)
+        _dec_lru.append(key)
+        return _dec_cache[key]
+    while len(_dec_cache) >= _CODEC_CACHE_MAX:
+        old = _dec_lru.pop(0)
+        _dec_cache.pop(old, None)
+        gc.collect()
+    dec = BakedDecoder(ensure_local(dec_rel(name, precision)), _THREADS,
+                       needs_even=(name == "same-s"))
+    _dec_cache[key] = dec
+    _dec_lru.append(key)
+    return dec
+
+
+def get_encoder(name: str, precision: str) -> BakedEncoder:
+    key = (name, precision)
+    if key in _enc_cache:
+        _enc_lru.remove(key)
+        _enc_lru.append(key)
+        return _enc_cache[key]
+    while len(_enc_cache) >= _CODEC_CACHE_MAX:
+        old = _enc_lru.pop(0)
+        _enc_cache.pop(old, None)
+        gc.collect()
+    enc = BakedEncoder(ensure_local(enc_rel(name, precision)), _THREADS,
+                       needs_even=(name == "same-s"))
+    _enc_cache[key] = enc
+    _enc_lru.append(key)
+    return enc
+
+
+# ── One full generation (mirrors sa3_tflite.py main(), all modes) ─────────────
+def run_generation(dit_name: str, decoder_name: str, precision: str, prompt: str,
+                   negative_prompt: str, seconds: float, steps: int,
+                   seed: int, cfg: float, apg: float, sigma_max: float,
+                   a2a_audio_path: str | None = None,
+                   inpaint_audio_path: str | None = None,
+                   inpaint_range_sec=None,
+                   lora_specs=None, cfg_batched: bool = True):
+    """Returns (audio_np (2,T) float32, timings dict).
+
+    a2a and inpainting are independent and combinable (same as the MLX UI):
+      - a2a_audio_path: the whole generation STARTS from this audio's latents
+        (x0 = lat*(1-σmax) + noise*σmax)
+      - inpaint_audio_path + inpaint_range_sec: kept bit-exact outside the range
+        (local_add_cond context + per-step paste-back)
+      - both: the inpainted span regenerates FROM the a2a guide instead of pure noise
+    """
+    t = {}
+    dec = decoder_name
+    needs_even = (dec == "same-s")
+    T_lat = valid_T_lat(seconds)
+
+    # 1. T5Gemma (tokenize + encode; + negative prompt for CFG)
+    t0 = time.time()
+    t5, tok = get_t5()
+    ids, mask = tok(prompt)
+    t5_hidden = t5(ids, mask)
+    null_h = null_m = None
+    if cfg != 1.0:
+        if negative_prompt and negative_prompt.strip():
+            n_ids, n_mask = tok(negative_prompt.strip())
+            null_h = t5(n_ids, n_mask)
+            null_m = n_mask.astype(np.float32)
+        else:
+            # All-zero hidden+mask → in-graph conditioner emits learned padding
+            # embeds for every position (the standard unconditional branch).
+            null_h = np.zeros((1, COND_TOKENS, COND_DIM), np.float32)
+            null_m = np.zeros((1, COND_TOKENS), np.float32)
+    t["t5_ms"] = (time.time() - t0) * 1000
+
+    # 2. Encode the provided audio inputs → latents (each optional). Memoized by
+    #    (file content, codec, precision, T_lat) so re-running with the same audio
+    #    skips the encoder.
+    def encode_audio(path):
+        import hashlib
+        ck = (hashlib.sha1(Path(path).read_bytes()).hexdigest(), dec, precision, T_lat)
+        if ck in _latent_cache:
+            t["enc_cached"] = t.get("enc_cached", 0) + 1
+            return _latent_cache[ck]
+        enc = get_encoder(dec, precision)
+        # SAME-S encoder needs even L; round the encode grid up, trim to T_lat.
+        enc_L = T_lat + 1 if (needs_even and T_lat % 2 != 0) else T_lat
+        target = enc_L * SAMPLES_PER_LATENT
+        audio_np = read_audio_any(path)
+        if audio_np.shape[-1] >= target:
+            audio_np = audio_np[:, :target]
+        else:
+            audio_np = np.pad(audio_np, ((0, 0), (0, target - audio_np.shape[-1])))
+        lat = enc.encode(audio_np[None], T_lat)   # (1,256,T_lat)
+        while len(_latent_cache) >= _LATENT_CACHE_MAX:
+            _latent_cache.pop(next(iter(_latent_cache)))
+        _latent_cache[ck] = lat
+        return lat
+
+    a2a_latents = None      # start-point guide (whole clip)
+    ctx_latents = None      # inpaint context (kept outside the range)
+    t["enc_ms"] = 0.0
+    if a2a_audio_path:
+        t0 = time.time()
+        a2a_latents = encode_audio(a2a_audio_path)
+        t["enc_ms"] += (time.time() - t0) * 1000
+    if inpaint_audio_path and inpaint_range_sec is not None:
+        t0 = time.time()
+        ctx_latents = encode_audio(inpaint_audio_path)
+        t["enc_ms"] += (time.time() - t0) * 1000
+
+    # 3. inpaint local_add_cond + paste-back (TRT channel layout: [1,257,L])
+    local_add_cond = None
+    paste_back = None
+    if ctx_latents is not None:
+        s0 = max(0, int(round(inpaint_range_sec[0] * SAMPLE_RATE / SAMPLES_PER_LATENT)))
+        s1 = min(T_lat, int(round(inpaint_range_sec[1] * SAMPLE_RATE / SAMPLES_PER_LATENT)))
+        keep = np.ones((1, 1, T_lat), np.float32)
+        keep[:, :, s0:s1] = 0.0                       # 1=keep init, 0=regenerate
+        masked = ctx_latents.astype(np.float32) * keep
+        local_add_cond = np.concatenate([keep, masked], axis=1)   # (1,257,T_lat)
+        paste_back = (ctx_latents.astype(np.float32), keep)
+
+    # 4. initial noise + a2a start-point mix (independent of inpainting)
+    x0, step_noise = P.make_noise(T_lat, steps, seed)
+    if a2a_latents is not None:
+        x0 = a2a_latents.astype(np.float32) * (1.0 - sigma_max) + x0 * sigma_max
+
+    # 5. DiT load (+ optional LoRA patch) + pingpong sample
+    dit_path = ensure_local(dit_rel(dit_name, precision))
+    if lora_specs:
+        # Raises LoraError for quantized-int8 precisions (caught upstream → error box).
+        dit_path = get_patched_dit(dit_path, lora_specs, family=dit_name,
+                                   precision=precision, log=lambda m: print(f"  {m}"))
+    backend, t["dit_load_ms"] = get_dit(str(dit_path), T_lat, t5_hidden,
+                                        mask.astype(np.float32), float(seconds),
+                                        cfg, apg, null_h, null_m, local_add_cond,
+                                        cfg_batched)
+    sigmas = P.build_pingpong_schedule(steps, sigma_max)
+    t0 = time.time()
+    latents = P.sample(backend, x0, step_noise, sigmas, None, None, paste_back=paste_back)
+    t["sample_ms"] = (time.time() - t0) * 1000
+    t["n_fwd"] = backend.n_fwd
+
+    # 6. Decode (whole for SAME-S; chunked for SAME-L past the window)
+    decoder = get_decoder(dec, precision)
+    t0 = time.time()
+    if dec == "same-l" and T_lat > SAMEL_CHUNK:
+        audio = decoder.decode_chunked(latents, SAMEL_CHUNK, SAMEL_OVERLAP)
+    else:
+        audio = decoder.decode_whole(latents)
+    t["decode_ms"] = (time.time() - t0) * 1000
+
+    audio_np = audio[0]                               # (2, L*4096)
+    requested = int(round(seconds * SAMPLE_RATE))
+    if audio_np.shape[-1] > requested:
+        audio_np = audio_np[..., :requested]
+
+    t["T_lat"] = T_lat
+    t["samples"] = audio_np.shape[-1]
+    t["inference_ms"] = sum(t.get(k, 0) for k in
+                            ("t5_ms", "enc_ms", "dit_load_ms", "sample_ms", "decode_ms"))
+    t["realtime"] = (audio_np.shape[-1] / SAMPLE_RATE) / max(t["inference_ms"] / 1000, 1e-9)
+    return audio_np, t
+
+
+# ── HTML rendering (inline handlers only — gradio HTML runs attributes, not
+# <script> tags) ────────────────────────────────────────────────────────────
+# One-at-a-time playback. Chrome does NOT stop a playing <audio> when it's
+# removed from the DOM (verified via CDP: swapped-out elements keep playing as
+# detached ghosts), and querySelectorAll can't see detached nodes — so every
+# player registers itself in window._sa3All on play, and pause-others sweeps
+# that registry (reaching ghosts) plus the document. Entries that are detached
+# AND paused drop from the registry so ghosts can be garbage-collected.
+# A DETACHED element's play event must never silence the living player (the
+# swap can briefly leave a superseded copy whose pending play() resolves late).
+# gradio's slider track fill lives in an inline CSS var (--range_progress) that
+# is only written on user input / first mount — a slider REmounted by a
+# visibility toggle (LoRA slots on model switch / add) comes back without it and
+# renders a blank track. Recompute it client-side after any remount batch;
+# idempotent for healthy sliders (same formula gradio uses).
+_JS_FIX_SLIDERS = (
+    "() => setTimeout(() => {"
+    "document.querySelectorAll('input[type=range]').forEach(r => {"
+    "const min = +r.min || 0, max = +r.max || 100, v = +r.value;"
+    "if (max > min) r.style.setProperty('--range_progress',"
+    "((v - min) / (max - min) * 100) + '%');"
+    "});}, 150)"
+)
+
+_JS_PAUSE_OTHERS = (
+    "if(this.isConnected){"
+    "var t=this;var L=window._sa3All=(window._sa3All||[]);"
+    "if(L.indexOf(t)<0)L.push(t);"
+    "L.forEach(function(o){if(o!==t){try{o.pause()}catch(e){}}});"
+    "document.querySelectorAll('audio').forEach(function(o){if(o!==t)o.pause();});"
+    "window._sa3All=L.filter(function(o){return o===t||o.isConnected;});}"
+    "else{this.pause();}")
+_JS_PLAYHEAD = ("var p=this.closest('.blk').querySelector('.ph');"
+                "if(p&&this.duration)p.style.left=(this.currentTime/this.duration*100)+'%';")
+# Main-player position ledger (for Hotswap): every timeupdate/play/pause stamps
+# the current position so a freshly swapped-in element can resume exactly there.
+# Guards (all verified via CDP against the live page):
+#  - isConnected: teardown fires a pause AND a final timeupdate on the removed
+#    element — detached elements never write the ledger.
+#  - unresumed hotswap candidates (data-hs set, hsd not yet) don't write either:
+#    with autoplay, the NEW element's 'play' event fires BEFORE loadedmetadata
+#    and would stamp t≈0 over the old clip's position right before the resume
+#    handler reads it.
+_JS_POS_RECORD = ("if(this.isConnected&&!(this.dataset.hs==='1'&&!this.dataset.hsd))"
+                  "{window._sa3Pos={t:this.currentTime,playing:!this.paused,ts:Date.now()};}")
+# timeupdate variant: a PAUSED element only fires timeupdate on seeks — e.g. the
+# resume handler's own currentTime assignment. Stamping playing:false there
+# poisons the ledger for any second render of the same clip (gradio sometimes
+# renders a component update twice), which froze the handoff chain. While
+# paused, only real pause events may write.
+_JS_POS_RECORD_TU = ("if(this.isConnected&&!this.paused&&"
+                     "!(this.dataset.hs==='1'&&!this.dataset.hsd))"
+                     "{window._sa3Pos={t:this.currentTime,playing:true,ts:Date.now()};}")
+# Resilient play: Chrome's autoplay policy can reject programmatic play() once
+# the transient user activation from the Generate click has expired (seconds),
+# leaving the clip correctly positioned but paused. Try, retry shortly after,
+# and as a last resort arm a one-shot listener so the user's next click or
+# keypress anywhere resumes playback.
+# Every attempt re-checks isConnected: a superseded (detached) element must
+# never revive itself from a queued retry and fight the current player.
+_JS_TRY_PLAY = (
+    "var A=this;A.play().catch(function(){setTimeout(function(){"
+    "if(!A.isConnected)return;"
+    "A.play().catch(function(){console.warn('play blocked by autoplay policy — "
+    "will resume on next interaction');"
+    "var f=function(){if(A.isConnected)A.play();"
+    "document.removeEventListener('pointerdown',f,true);"
+    "document.removeEventListener('keydown',f,true);};"
+    "document.addEventListener('pointerdown',f,true);"
+    "document.addEventListener('keydown',f,true);});},150);});")
+# Hotswap resume: if the previous main audio was playing when this one arrived,
+# jump to its position (+ the split-second since the last stamp) and keep going;
+# beyond the new clip's duration -> start at zero. Guarded (hsd) so it applies
+# once, on whichever of loadedmetadata/canplay fires first.
+_JS_HOTSWAP = ("if(this.isConnected&&this.dataset.hs==='1'&&!this.dataset.hsd&&this.duration){"
+               "this.dataset.hsd=1;var s=window._sa3Pos;"
+               "this.dataset.dbg=s?(s.playing?'playing@'+s.t.toFixed(2):'notplaying@'+s.t.toFixed(2)):'noledger';"
+               "if(s&&s.playing){var tt=s.t+(Date.now()-s.ts)/1000;"
+               "this.currentTime=(tt<this.duration)?tt:0;" + _JS_TRY_PLAY + "}}")
+_JS_SEEK = ("var a=this.closest('.blk').querySelector('audio');"
+            "var r=this.getBoundingClientRect();"
+            "if(a&&a.duration){a.currentTime=(event.clientX-r.left)/r.width*a.duration;a.play();}")
+_JS_PROMOTE = ("var b=document.getElementById('sa3-promote');"
+               "if(b){(b.tagName==='BUTTON'?b:b.querySelector('button')||b).click();}")
+# Scroll anchoring for the history panel: onscroll continuously records which
+# item sits at the viewport top (+offset); after every re-render a hidden
+# bootstrap <img onerror> restores that anchor — stick-to-top when at top,
+# otherwise keep hovering over the same old item as new ones prepend.
+_JS_SCROLL_RECORD = (
+    "var c=this,k=null,off=0,ch=c.querySelectorAll('[data-key]');"
+    "for(var i=0;i<ch.length;i++){if(ch[i].offsetTop+ch[i].offsetHeight>c.scrollTop)"
+    "{k=ch[i].getAttribute('data-key');off=ch[i].offsetTop-c.scrollTop;break}}"
+    "window._sa3S={atTop:c.scrollTop<8,key:k,off:off};")
+_JS_SCROLL_RESTORE = (
+    "var c=document.getElementById('sa3-hist');var s=window._sa3S||{};"
+    "if(c){var el=s.key?c.querySelector('[data-key=&quot;'+s.key+'&quot;]'):null;"
+    "if(el&&!s.atTop){c.scrollTop=el.offsetTop-(s.off||0)}else{c.scrollTop=0}}"
+    "this.remove();")
+
+
+def _ago(ts) -> str:
+    if not ts:
+        return ""
+    d = max(0.0, time.time() - ts)
+    if d < 10:
+        return "just now"
+    if d < 60:
+        return f"{int(d)}s ago"
+    if d < 3600:
+        return f"{int(d // 60)}m ago"
+    if d < 86400:
+        return f"{int(d // 3600)}h ago"
+    return f"{int(d // 86400)}d ago"
+
+
+def _lora_specs_from_ui(vals, notes):
+    """Turn the 3 LoRA slots' flat values (file, dropdown, strength)×3 into
+    lora_core specs. A slot's adapter is the dropped file or, failing that, the
+    dropdown pick from ./loras/<model>/; empty slots are skipped. Unlike the MLX
+    UI there is no per-step range (the frozen TFLite graph merges once at load).
+    A bad spec gets a note and is skipped (never an error — matches the app's
+    permissive-by-design generation policy)."""
+    specs = []
+    for i in range(3):
+        path, picked, strength = vals[3 * i: 3 * i + 3]
+        if not path:
+            path = picked if picked and picked != _DD_NONE else None
+        if not path:
+            continue
+        try:
+            specs.append(parse_lora_spec([path, f"strength={float(strength)}"]))
+        except LoraError as e:
+            notes.append(f"LoRA {i + 1}: {e}")
+    return specs or None
+
+
+def _lora_disp(specs) -> str:
+    """Short human tag per adapter: 'plini×0.8, rain'."""
+    tags = []
+    for s in specs or []:
+        name = Path(s["path"]).stem
+        if len(name) > 25:
+            name = name[:24] + "…"
+        tag = name
+        if s["strength"] != 1.0:
+            tag += f"×{s['strength']:g}"
+        tags.append(tag)
+    return ", ".join(tags)
+
+
+def _meta_suffix(entry) -> str:
+    """' · sm-mus · w8a32 · cfg 1.5 · noise 0.92 · audio2audio · inpainting' —
+    only the non-defaults. The sigma tag reads 'noise' for a2a runs (it IS the
+    init_noise_level there), 'smx' otherwise."""
+    parts = []
+    cfg = entry.get("cfg", 1.0)
+    smx = entry.get("smx", 1.0)
+    mode = entry.get("mode", "")
+    is_a2a = "a2a" in mode or mode == "audio-to-audio"
+    dit = entry.get("dit", "")
+    prec = entry.get("prec", "fp32")
+    if dit:
+        parts.append({"medium": "med", "sm-music": "sm-mus", "sm-sfx": "sm-sfx"}.get(dit, dit))
+    if prec and prec != "fp32":
+        parts.append(prec)
+    if cfg != 1.0:
+        parts.append(f"cfg {cfg:g}")
+    if smx != 1.0:
+        parts.append(f"{'noise' if is_a2a else 'smx'} {smx:g}")
+    if is_a2a:
+        parts.append("audio2audio")
+    if "inpaint" in mode:
+        parts.append("inpainting")
+    if entry.get("lora"):
+        parts.append(f"lora {entry['lora']}")
+    return "".join(f" · {p}" for p in parts)
+
+
+def _neg_disp(entry) -> str:
+    """Labeled negative prompt, shown only when it actually acted (cfg != 1)."""
+    neg = (entry.get("neg") or "").strip()
+    if neg and entry.get("cfg", 1.0) != 1.0:
+        return f' · <span style="opacity:0.75">neg: {html_lib.escape(neg)}</span>'
+    return ""
+
+
+def render_player(entry, *, small=False, autoplay=False, autodl=False, radio=False,
+                  bg=None, advance=False, loop=False, hotswap=False):
+    """One self-contained player block: audio + caption + seekable spectrogram
+    with playhead. Global one-at-a-time playback via onplay pause-others.
+    small: audio + spectrogram side by side (half width each), 'Xm ago' caption.
+    advance: on ended, hop to the next history item's audio (Auto-play).
+    loop: native loop attribute — finished audio restarts (suppresses ended).
+    hotswap: main slot only — resume at the previous clip's position on arrival."""
+    # assemble per-event handler bodies (a duplicated attribute name would
+    # silently drop one handler, so each event is emitted exactly once)
+    on_canplay = []
+    if small:
+        attrs = f'onplay="{_JS_PAUSE_OTHERS}" ontimeupdate="{_JS_PLAYHEAD}"'
+    else:
+        attrs = (f'onplay="{_JS_PAUSE_OTHERS}{_JS_POS_RECORD}" '
+                 f'onpause="{_JS_POS_RECORD}" '
+                 f'ontimeupdate="{_JS_PLAYHEAD}{_JS_POS_RECORD_TU}"')
+    if hotswap and not small:
+        attrs += f' data-hs="1" onloadedmetadata="{_JS_HOTSWAP}"'
+        on_canplay.append(_JS_HOTSWAP)   # fallback if loadedmetadata already passed
+    if autoplay and not small:
+        # the autoplay attribute is subject to the same policy — rescue a
+        # policy-paused clip (radio transitions, long generations)
+        on_canplay.append("if(this.paused&&!(this.dataset.hs==='1'&&!this.dataset.hsd))"
+                          "{" + _JS_TRY_PLAY + "}")
+    if autodl:
+        js_name = entry["name"].replace("\\", "").replace("'", "\\'")
+        on_canplay.append("if(!this.dataset.dld){this.dataset.dld=1;"
+                          "var l=document.createElement('a');l.href=this.src;"
+                          f"l.download='{js_name}';l.click();}}")
+    if on_canplay:
+        attrs += f' oncanplay="{"".join(on_canplay)}"'
+    if loop:
+        attrs += " loop"
+    elif radio:
+        attrs += f' onended="{_JS_PROMOTE}"'
+    elif advance:
+        attrs += (' onended="var b=this.closest(\'.blk\');'
+                  "var n=b?b.nextElementSibling:null;"
+                  "while(n&&!n.classList.contains('blk'))n=n.nextElementSibling;"
+                  "if(n){var a=n.querySelector('audio');if(a)a.play();}\"")
+    auto = "autoplay " if autoplay else ""
+    # Serve audio via gradio's file route instead of a data: URI — the URL ends
+    # with the real (verbose) filename, so right-click "Save audio as…" offers
+    # it instead of download.mp3, and the page stays light as history grows.
+    src = "gradio_api/file=" + urllib.parse.quote(entry["path"], safe="/")
+    audio_el = (f'<audio controls {auto}style="width:100%" {attrs} '
+                f'src="{src}"></audio>')
+    prompt_disp = html_lib.escape(entry["prompt"]) or "<i>(no prompt)</i>"
+
+    spec_core = ""
+    if entry.get("spec_b64"):
+        height = "height:56px;" if small else ""
+        tip = ("3-band tinted stereo mel · red=bass / green=mid / blue=high · "
+               "L top, R bottom · click to seek")
+        spec_core = (f'<div style="position:relative; cursor:pointer" title="{tip}" '
+                     f'onclick="{_JS_SEEK}">'
+                     f'<img src="data:image/png;base64,{entry["spec_b64"]}" '
+                     f'style="width:100%; {height} display:block; image-rendering:pixelated; '
+                     f'border:1px solid #333" alt="spectrogram"/>'
+                     f'<div class="ph" style="position:absolute; top:0; bottom:0; left:0%; '
+                     f'width:2px; background:#fff; pointer-events:none; '
+                     f'box-shadow:0 0 4px rgba(0,0,0,.8)"></div>'
+                     f'</div>')
+
+    if small:
+        row = (f'<div style="display:flex; gap:8px; align-items:center">'
+               f'<div style="flex:1; min-width:0">{audio_el}</div>'
+               f'<div style="flex:1; min-width:0">{spec_core}</div></div>')
+        cap = (f'<div style="font-size:0.8em; margin:2px 0; color:#888">'
+               f'{_ago(entry.get("ts"))} · {prompt_disp}{_neg_disp(entry)} · seed {entry["seed"]}'
+               f'{_meta_suffix(entry)}</div>')
+        style = f"padding:6px 8px;{' background:' + bg + ';' if bg else ''}"
+        return (f'<div class="blk" data-key="{entry["key"]}" style="{style}">'
+                f'{row}{cap}</div>')
+
+    return (f'<div class="blk" data-key="{entry["key"]}">'
+            f'{audio_el}{spec_core}</div>')
+
+
+def render_history(hist, advance=False, loop=False):
+    if not hist:
+        return ""
+    # zebra striping instead of separators: light grey vs medium grey rows
+    items = "".join(
+        render_player(e, small=True, advance=advance, loop=loop,
+                      bg="rgba(127,127,127,0.24)" if i % 2 else "rgba(127,127,127,0.08)")
+        for i, e in enumerate(hist))
+    boot = f'<img src="data:," style="display:none" onerror="{_JS_SCROLL_RESTORE}"/>'
+    return (f'<div style="font-weight:600; margin-top:14px">Previous generations ({len(hist)})</div>'
+            f'<div id="sa3-hist" onscroll="{_JS_SCROLL_RECORD}" '
+            f'style="max-height:480px; overflow-y:auto; position:relative; margin-top:6px; '
+            f'padding-right:6px">{boot}{items}</div>')
+
+
+def render_queue_status(entry=None, generating=False):
+    """Subdued status chip for the Infinite Radio queue — no audio/spectrogram,
+    just Generating…/Ready (the swap uses the entry held in server state)."""
+    if generating:
+        body = "generating…"
+    elif entry is not None:
+        p = html_lib.escape(entry["prompt"]) or "<i>(no prompt)</i>"
+        body = f"ready — {p}{_neg_disp(entry)} · seed {entry['seed']}{_meta_suffix(entry)}"
+    else:
+        return ""
+    return (f'<div style="margin-top:2px; padding:6px 10px; '
+            f'background:rgba(127,127,127,0.12); border-radius:6px; '
+            f'color:#888; font-size:0.85em">'
+            f'<b>Queued next</b> · {body}</div>')
+
+
+# ── Gradio UI ──────────────────────────────────────────────────────────────
+def build_ui(initial_dit: str, initial_decoder: str, initial_precision: str, *,
+             share: bool, default_seconds: float, default_steps: int,
+             server_port: int | None = None):
+    import gradio as gr
+    import random as _random
+
+    # Pre-warm the initial pipeline so the first click is fast — ON the owner
+    # thread, so all model state lives where generations run.
+    warm_T = valid_T_lat(default_seconds)
+    print(f"  pre-warming {initial_dit}+{initial_decoder} @ {initial_precision} (T_lat={warm_T})...")
+
+    def _warm():
+        t5, tok = get_t5()
+        ids, mask = tok("")
+        t5h = t5(ids, mask)
+        get_dit(str(ensure_local(dit_rel(initial_dit, initial_precision))), warm_T,
+                t5h, mask.astype(np.float32), float(default_seconds),
+                1.0, 1.0, None, None, None, True)
+        get_decoder(initial_decoder, initial_precision)
+    try:
+        run_serial(_warm)
+    except Exception as e:
+        print(f"  (warm-up skipped: {type(e).__name__}: {e})")
+
+    def on_dit_change(dit_name, cur_seconds, prev, mem, vis, *slot_vals):
+        """Model switch: pair the decoder, clamp seconds, and swap the LoRA
+        panel to the new model — the outgoing model's slots (files, picks,
+        strengths, visibility) are snapshotted into per-model memory and the
+        incoming model's snapshot is restored (or an empty panel). Dropdowns
+        rescan loras/<model>/ (hidden when empty)."""
+        max_s = MAX_SECONDS.get(dit_name, 120)
+        ch = _lora_dd_choices(dit_name)
+        valid = {v for _, v in ch}
+        lbl = f"…or pick from loras/{LORA_DIR_NAMES.get(dit_name, dit_name)}/"
+
+        mem = dict(mem or {})
+        mem[prev] = {"vis": list(vis),
+                     "slots": [list(slot_vals[3 * i: 3 * i + 3]) for i in range(3)]}
+        snap = mem.get(dit_name)
+        if snap:
+            nvis = list(snap["vis"])
+            slots = [list(s) for s in snap["slots"]]
+            for s in slots:
+                if s[1] not in valid:
+                    s[1] = _DD_NONE
+            # a slot with an adapter must never be an invisible-but-active one
+            nvis = [v or bool(s[0] or s[1] != _DD_NONE)
+                    for v, s in zip(nvis, slots)]
+        else:
+            nvis = [False, False, False]
+            slots = [[None, _DD_NONE, 1.0] for _ in range(3)]
+
+        dd_ups = [gr.update(choices=ch, value=slots[i][1], visible=len(ch) > 1,
+                            label=lbl) for i in range(3)]
+        srow_ups = [gr.update(visible=bool(slots[i][0] or slots[i][1] != _DD_NONE))
+                    for i in range(3)]
+        row_ups = [gr.update(visible=v) for v in nvis]
+        return (gr.update(value=DEFAULT_DECODERS.get(dit_name, "same-s")),
+                gr.update(maximum=max_s, value=min(cur_seconds, max_s)),
+                *dd_ups, *srow_ups, *row_ups,
+                gr.update(visible=not all(nvis)), nvis, dit_name, mem,
+                slots[0][0], slots[1][0], slots[2][0],
+                slots[0][2], slots[1][2], slots[2][2])
+
+    def _generate_entry(dit_name, precision, decoder_name, prompt, negative_prompt,
+                        seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
+                        a2a_audio, inpaint_audio, inp_start, inp_end,
+                        output_opts, file_format, *lora_vals):
+        """Run one generation and package it as a history entry.
+        Returns (entry, None) or (None, error_message)."""
+        prompt = (prompt or "").strip()
+        # Permissive by design: a generation should succeed with whatever IS set.
+        # Half-configured features are ignored with a visible note, never an error.
+        notes = []
+        lora_specs = (_lora_specs_from_ui(lora_vals, notes) if lora_vals else None)
+        if lora_specs and precision not in LORA_PRECISIONS:
+            # UI already hides LoRA under int8; this is the belt-and-braces guard for
+            # API callers / stale state. get_patched_dit would raise anyway — surface
+            # it as a clean note + skip the LoRA rather than failing the generation.
+            notes.append(f"LoRA ignored — precision {precision} can't be LoRA-merged "
+                         f"(needs fp32 or w16a32)")
+            lora_specs = None
+        # blank or -1 → random seed, kept small (1-9999) for readability
+        try:
+            seed = int(seed_text.strip()) if seed_text and seed_text.strip() else -1
+        except ValueError:
+            seed = -1
+            notes.append("seed wasn't an integer — used a random one")
+        if seed == -1:
+            seed = _random.randint(1, 9999)
+        # backstop for API callers bypassing the slider maxima
+        max_s = MAX_SECONDS.get(dit_name, 120)
+        if seconds > max_s:
+            notes.append(f"seconds clamped to {dit_name}'s trained max ({max_s:g}s)")
+            seconds = float(max_s)
+        # sigma_max governs every generation's schedule start; when guide audio is
+        # present (a2a), init_noise_level overrides it (parent-repo gradio semantics).
+        sigma_max = float(init_noise) if a2a_audio else float(sigma_max)
+        if sigma_max < MIN_SIGMA:
+            which = "init_noise_level" if a2a_audio else "sigma_max"
+            notes.append(f"{which} 0 runs at {MIN_SIGMA} (model is undefined at t≈0)"
+                         + (" — output ≈ the re-encoded input" if a2a_audio else ""))
+            sigma_max = MIN_SIGMA
+
+        inpaint_range = None
+        if inpaint_audio and inp_end > inp_start and inp_start < seconds:
+            if inp_end > seconds:
+                notes.append(f"inpaint end clamped to the clip length ({seconds:g}s)")
+            inpaint_range = (float(inp_start), float(min(inp_end, seconds)))
+        elif inpaint_audio:
+            notes.append("inpainting ignored — set the start/end range sliders")
+        elif inp_end > inp_start:
+            notes.append("inpaint range ignored — no reference audio uploaded")
+
+        opts = output_opts or []
+        if ("Infinite Radio" in opts and seed_text and seed_text.strip()
+                and seed_text.strip() != "-1"):
+            notes.append("Infinite Radio with a fixed seed repeats the same clip — "
+                         "clear the seed for endless variety")
+
+        mode = ("a2a+inpaint" if (a2a_audio and inpaint_range) else
+                "inpaint" if inpaint_range else
+                "audio-to-audio" if a2a_audio else "text-to-audio")
+        try:
+            audio_np, t = run_serial(
+                run_generation,
+                dit_name, decoder_name, precision, prompt, negative_prompt or "",
+                float(seconds), int(steps), seed, float(cfg), float(apg),
+                float(sigma_max), a2a_audio or None, inpaint_audio or None,
+                inpaint_range, lora_specs)
+        except LoraError as e:
+            return None, f"LoRA error: {e}"
+        except Exception as e:
+            return None, f"error: {type(e).__name__}: {e}"
+        if not np.isfinite(audio_np).all():
+            return None, "error: model produced non-finite audio (try a higher σmax or different seed)"
+
+        pcm = (np.clip(audio_np, -1, 1) * 32767.0).astype(np.int16).T   # (T, 2)
+        basename = verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed, precision)
+        out_path = OUTPUT_DIR / f"{basename}.wav"
+        _save_wav(pcm, out_path)
+        mime = "audio/wav"
+        if FFMPEG and file_format == FORMAT_MP3:
+            mp3_path = OUTPUT_DIR / f"{basename}.mp3"
+            r = subprocess.run(["ffmpeg", "-y", "-v", "error", "-i", str(out_path),
+                                "-codec:a", "libmp3lame", "-q:a", "0", str(mp3_path)],
+                               capture_output=True)
+            if r.returncode == 0 and mp3_path.exists():
+                out_path.unlink()
+                out_path, mime = mp3_path, "audio/mpeg"
+            else:
+                notes.append("mp3 encode failed — saved WAV instead")
+
+        spec_b64 = None
+        try:
+            spec_png = render_spectrogram_png(pcm, sample_rate=SAMPLE_RATE,
+                                              width=1200, height=240)
+            spec_b64 = base64.b64encode(spec_png).decode("ascii")
+        except Exception as e:
+            notes.append(f"spectrogram failed: {type(e).__name__}: {e}")
+
+        load_note = (f"DiT-load {t['dit_load_ms']:.0f} ms ·&nbsp; "
+                     if t.get("dit_load_ms", 0) > 100 else "")
+        cached_tag = " (cached)" if t.get("enc_cached") else ""
+        enc_note = f"encode {t['enc_ms']:.0f} ms{cached_tag} ·&nbsp; " if t.get("enc_ms") else ""
+        prec_note = f"<b>precision</b>: {precision} ·&nbsp; " if precision != "fp32" else ""
+        apg_note = f" (apg {apg:g})" if apg != 1.0 else ""
+        cfg_note = f"cfg {cfg:g}{apg_note} ·&nbsp; " if cfg != 1.0 else ""
+        lora_note = (f"<b>lora</b>: {html_lib.escape(_lora_disp(lora_specs))} ·&nbsp; "
+                     if lora_specs else "")
+        prompt_disp = html_lib.escape(prompt) or "<i>(no prompt)</i>"
+        neg_disp = (f' · <span style="opacity:0.75">neg: {html_lib.escape(negative_prompt.strip())}</span>'
+                    if negative_prompt and negative_prompt.strip() and cfg != 1.0 else "")
+        timing_html = (
+            f"{prompt_disp}{neg_disp} ·&nbsp; "
+            f"{prec_note}{load_note}{enc_note}{cfg_note}{lora_note}"
+            f"<b>Inference</b>: {t['inference_ms']:.0f} ms "
+            f"<span style='color:#888'>(t5={t['t5_ms']:.0f} · sample={t['sample_ms']:.0f} · "
+            f"decode={t['decode_ms']:.0f})</span> ·&nbsp; "
+            f"<b>{t['realtime']:.1f}× realtime</b> ·&nbsp; "
+            f"<b>seed</b>: <code>{seed}</code> ·&nbsp; "
+            f"<b>seq_len</b>: {t['T_lat']} ·&nbsp; <b>samples</b>: {t['samples']}"
+        )
+        if notes:
+            timing_html = ("".join(f"<div style='color:#fa3; font-size:0.85em'>note: {n}</div>"
+                                   for n in notes) + timing_html)
+
+        entry = {
+            "key": f"k{time.time_ns()}",
+            "ts": time.time(),
+            "dit": dit_name,
+            "prec": precision,
+            "neg": (negative_prompt or "").strip(),
+            "cfg": float(cfg),
+            "smx": float(sigma_max),
+            "path": str(out_path),
+            "mime": mime,
+            "name": out_path.name,
+            "size_mb": out_path.stat().st_size / 1e6,
+            "mode": mode,
+            "prompt": prompt,
+            "seed": seed,
+            "lora": _lora_disp(lora_specs),
+            "spec_b64": spec_b64,
+            "timing": timing_html,
+        }
+        return entry, None
+
+    def _present(state, entry, opts, queued_panel, *, force_autoplay=False):
+        """Make `entry` the current clip (previous current moves to history top)
+        and render all output panels."""
+        if state["current"] is not None:
+            state["history"].insert(0, state["current"])
+        state["current"] = entry
+        loop = "Loop" in opts
+        main = render_player(entry,
+                             autoplay=force_autoplay or "Auto-play" in opts,
+                             autodl="Auto-download" in opts,
+                             radio="Infinite Radio" in opts and not loop,
+                             loop=loop,
+                             hotswap="Hotswap" in opts)
+        return (main, entry["timing"], "",
+                render_history(state["history"], advance="Auto-play" in opts, loop=loop),
+                queued_panel, state)
+
+    def generate(dit_name, precision, decoder_name, prompt, negative_prompt,
+                 seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
+                 a2a_audio, inpaint_audio, inp_start, inp_end,
+                 output_opts, file_format, *lora_and_state):
+        *lora_vals, state = lora_and_state
+        entry, err_msg = _generate_entry(
+            dit_name, precision, decoder_name, prompt, negative_prompt, seconds, steps,
+            seed_text, cfg, apg, sigma_max, init_noise, a2a_audio,
+            inpaint_audio, inp_start, inp_end, output_opts, file_format,
+            *lora_vals)
+        if entry is None:
+            return (gr.update(), gr.update(),
+                    f"<span style='color:#f88'>{err_msg}</span>",
+                    gr.update(), gr.update(), state)
+        # a manual Generate makes any queued clip stale (settings may have changed);
+        # the chained pregen refills it when Infinite Radio is on
+        state["queued"] = None
+        opts = output_opts or []
+        queued_panel = render_queue_status(generating=True) if "Infinite Radio" in opts else ""
+        return _present(state, entry, opts, queued_panel)
+
+    def promote(dit_name, precision, decoder_name, prompt, negative_prompt,
+                seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
+                a2a_audio, inpaint_audio, inp_start, inp_end,
+                output_opts, file_format, *lora_and_state):
+        """Infinite Radio: swap the pre-generated clip in when playback ends.
+        Falls back to a full generate if the queue is empty. Either way the
+        next track ALWAYS autoplays — Auto-play only governs whether a clip
+        starts when nothing was playing; radio transitions are continuations."""
+        *lora_vals, state = lora_and_state
+        q = state.get("queued")
+        if q is None:
+            entry, err_msg = _generate_entry(
+                dit_name, precision, decoder_name, prompt, negative_prompt, seconds, steps,
+                seed_text, cfg, apg, sigma_max, init_noise, a2a_audio,
+                inpaint_audio, inp_start, inp_end, output_opts, file_format,
+                *lora_vals)
+            if entry is None:
+                return (gr.update(), gr.update(),
+                        f"<span style='color:#f88'>{err_msg}</span>",
+                        gr.update(), gr.update(), state)
+            q = entry
+        state["queued"] = None
+        return _present(state, q, output_opts or [],
+                        render_queue_status(generating=True), force_autoplay=True)
+
+    def pregen(dit_name, precision, decoder_name, prompt, negative_prompt,
+               seconds, steps, seed_text, cfg, apg, sigma_max, init_noise,
+               a2a_audio, inpaint_audio, inp_start, inp_end,
+               output_opts, file_format, *lora_and_state):
+        """Chained after generate/promote: pre-generate the NEXT clip while the
+        current one plays (Infinite Radio only)."""
+        *lora_vals, state = lora_and_state
+        if "Infinite Radio" not in (output_opts or []):
+            state["queued"] = None
+            return "", state
+        entry, err_msg = _generate_entry(
+            dit_name, precision, decoder_name, prompt, negative_prompt, seconds, steps,
+            seed_text, cfg, apg, sigma_max, init_noise, a2a_audio,
+            inpaint_audio, inp_start, inp_end, output_opts, file_format,
+            *lora_vals)
+        if entry is None:
+            return (f"<div style='color:#f88; font-size:0.85em'>queue: {err_msg}</div>",
+                    state)
+        state["queued"] = entry
+        return render_queue_status(entry), state
+
+    # sa3-promote must stay MOUNTED for the onended click to find it —
+    # visible=False would remove it from the DOM entirely, so hide via CSS.
+    # sa3-out: collapse the column's flex gap + wrapper padding so the
+    # spectrogram caption / timing line / queued status sit tightly together.
+    _css = ("#sa3-promote{display:none !important}"
+            "#sa3-out{gap:4px !important}"
+            "#sa3-out .html-container{padding:0 !important; margin:0 !important}")
+    with gr.Blocks(title="SA3 TFLite") as demo:
+        gr.Markdown(
+            "# SA3 TFLite — portable CPU (XNNPACK)\n"
+            "Text-to-audio, CFG + negative prompt, audio-to-audio, inpainting, LoRA. "
+            "Pick a precision (fp32 / w16a32 / w8a32 / w8a8-dyn). First use of a "
+            "model/precision loads weights; subsequent runs are cached."
+        )
+        st = gr.State({"current": None, "queued": None, "history": []})
+        with gr.Row():
+            with gr.Column(scale=3):
+                with gr.Row():
+                    dit_dd = gr.Dropdown(label="DiT model", choices=list(DIT_REL.keys()),
+                                         value=initial_dit, scale=1)
+                    precision_dd = gr.Dropdown(label="Precision", choices=list(PRECISIONS),
+                                               value=initial_precision, scale=1)
+                    decoder_dd = gr.Dropdown(label="Decoder (codec)",
+                                             choices=list(DEC_REL.keys()),
+                                             value=initial_decoder, scale=1)
+                with gr.Row():
+                    prompt = gr.Textbox(label="Prompt", lines=2, scale=6,
+                                        placeholder="e.g. 'Impending tribal, epic orchestral buildup'")
+                    seed = gr.Textbox(label="Seed (optional)", max_lines=1, value="",
+                                      scale=1, min_width=80)
+                with gr.Row():
+                    seconds = gr.Slider(label="Seconds", minimum=1,
+                                        maximum=MAX_SECONDS.get(initial_dit, 120),
+                                        value=default_seconds, step=1)
+                    steps = gr.Slider(label="Steps", minimum=1, maximum=16,
+                                      value=default_steps, step=1)
+                    cfg = gr.Slider(label="CFG", minimum=0.0, maximum=10.0,
+                                    value=1.0, step=0.1)
+
+                with gr.Accordion("Advanced", open=False):
+                    with gr.Row():
+                        apg = gr.Slider(label="APG (only applies when CFG > 1)",
+                                        minimum=0.0, maximum=1.0, value=1.0, step=0.05)
+                        sigma_global = gr.Slider(label="sigma_max",
+                                                 minimum=0.0, maximum=1.0, value=1.0, step=0.01)
+                    negative_prompt = gr.Textbox(label="Negative prompt", lines=1)
+
+                with gr.Accordion("LoRA", open=False):
+                    # Shown only under a quantized precision (LoRA disabled there).
+                    lora_note = gr.Markdown(
+                        "*LoRA needs precision **fp32** or **w16a32** — quantized-int8 "
+                        "graphs (w8a32 / w8a8-dyn) can't be LoRA-merged.*",
+                        visible=initial_precision not in LORA_PRECISIONS)
+                    with gr.Group(visible=initial_precision in LORA_PRECISIONS) as lora_editor:
+                        _dd0 = _lora_dd_choices(initial_dit)
+                        lora_inputs, lora_rows, lora_rm_btns = [], [], []
+                        lora_dds, lora_files, lora_srows = [], [], []
+                        for _i in range(1, 4):
+                            with gr.Group(visible=False) as _grp:
+                                with gr.Row(equal_height=True):
+                                    _lf = gr.File(label=f"LoRA {_i} (.safetensors)",
+                                                  file_types=[".safetensors"],
+                                                  type="filepath", scale=1, height=88)
+                                    _ld = gr.Dropdown(
+                                        label=f"…or pick from loras/{LORA_DIR_NAMES[initial_dit]}/",
+                                        choices=_dd0, value=_DD_NONE, scale=1,
+                                        visible=len(_dd0) > 1)
+                                    _rm = gr.Button("✕", size="sm", scale=0,
+                                                    min_width=36)
+                                with gr.Row(visible=False) as _srow:
+                                    _ls = gr.Slider(label="strength", minimum=0.0,
+                                                    maximum=10.0, value=1.0, step=0.1,
+                                                    scale=2, min_width=110)
+                            lora_rows.append(_grp)
+                            lora_rm_btns.append(_rm)
+                            lora_dds.append(_ld)
+                            lora_files.append(_lf)
+                            lora_srows.append(_srow)
+                            lora_inputs += [_lf, _ld, _ls]
+                        lora_add_btn = gr.Button("+ Add LoRA", size="sm")
+                    lora_vis = gr.State([False, False, False])
+                    # Per-model LoRA memory: switching DiT saves the outgoing
+                    # model's slots and restores the incoming model's.
+                    lora_mem = gr.State({})
+                    prev_dit = gr.State(initial_dit)
+
+                with gr.Accordion("Audio-to-audio (guide the whole clip)", open=False):
+                    a2a_audio = gr.Audio(label="Guide audio — generation starts from its latents",
+                                         type="filepath")
+                    sigma_slider = gr.Slider(
+                        label="init_noise_level (1.0 = prompt, ~0.92 = fusion, 0 = input)",
+                        minimum=0.0, maximum=1.0, value=0.92, step=0.01)
+
+                with gr.Accordion("Inpainting (regenerate a span of reference audio)", open=False):
+                    inpaint_audio = gr.Audio(label="Reference audio — kept bit-exact outside the range",
+                                             type="filepath")
+                    with gr.Row():
+                        inp_start = gr.Slider(label="Start (s)", minimum=0, maximum=120,
+                                              value=0, step=0.5)
+                        inp_end = gr.Slider(label="End (s)", minimum=0, maximum=120,
+                                            value=0, step=0.5)
+
+                with gr.Accordion("Output", open=False):
+                    output_opts = gr.CheckboxGroup(
+                        ["Auto-play", "Auto-download", "Infinite Radio", "Loop", "Hotswap"],
+                        value=["Auto-play"], label="Playback Options")
+                    opts_state = gr.State(["Auto-play"])
+                    file_format = gr.Radio(
+                        [FORMAT_MP3, FORMAT_WAV] if FFMPEG else [FORMAT_WAV],
+                        value=FORMAT_MP3 if FFMPEG else FORMAT_WAV,
+                        label="Format", visible=FFMPEG)
+
+            with gr.Column(scale=2, elem_id="sa3-out"):
+                generate_btn = gr.Button("Generate", variant="primary", size="lg",
+                                         elem_id="sa3-generate")
+                promote_btn = gr.Button("", elem_id="sa3-promote")   # CSS-hidden, DOM-present
+                gr.Markdown("**Output**")
+                output_player = gr.HTML()
+                timing = gr.HTML()
+                error_box = gr.HTML()
+                queued_html = gr.HTML()
+                history_html = gr.HTML()
+
+        def _sync_dd_vis(dit_name):
+            """Second batch after any group (re)mount: gradio 6 drops visibility
+            updates sent to components inside a hidden container (the component
+            isn't in the DOM), so dropdown show/hide must be applied AFTER the
+            slot groups are mounted — chained via .then() on every event that
+            reveals them."""
+            v = len(_lora_dd_choices(dit_name)) > 1
+            return [gr.update(visible=v) for _ in range(3)]
+
+        dit_dd.change(on_dit_change,
+                      inputs=[dit_dd, seconds, prev_dit, lora_mem,
+                              lora_vis] + lora_inputs,
+                      outputs=[decoder_dd, seconds] + lora_dds + lora_srows
+                              + lora_rows
+                              + [lora_add_btn, lora_vis, prev_dit, lora_mem]
+                              + lora_files
+                              + [lora_inputs[3 * i + 2] for i in range(3)]
+                      ).then(_sync_dd_vis, inputs=[dit_dd], outputs=lora_dds
+                      ).then(None, js=_JS_FIX_SLIDERS)
+
+        def on_precision_change(prec):
+            """Quantized-int8 precisions can't be LoRA-merged — hide the editor
+            and show the note. fp32 / w16a32 re-enable it."""
+            disabled = prec not in LORA_PRECISIONS
+            return gr.update(visible=disabled), gr.update(visible=not disabled)
+        precision_dd.change(on_precision_change, inputs=[precision_dd],
+                            outputs=[lora_note, lora_editor]
+                            ).then(_sync_dd_vis, inputs=[dit_dd], outputs=lora_dds
+                            ).then(None, js=_JS_FIX_SLIDERS)
+
+        def on_seconds_change(sec):
+            return gr.update(maximum=sec), gr.update(maximum=sec)
+        seconds.change(on_seconds_change, inputs=[seconds], outputs=[inp_start, inp_end])
+
+        def on_opts_change(opts, prev):
+            """Loop and Infinite Radio are mutually exclusive — the one just
+            ticked wins, the other unticks."""
+            opts = opts or []
+            if "Loop" in opts and "Infinite Radio" in opts:
+                added = set(opts) - set(prev or [])
+                drop = "Infinite Radio" if "Loop" in added else "Loop"
+                opts = [o for o in opts if o != drop]
+                return gr.update(value=opts), opts
+            return gr.update(), opts
+        output_opts.change(on_opts_change, inputs=[output_opts, opts_state],
+                           outputs=[output_opts, opts_state])
+
+        def lora_add(vis, dit_name, f1, d1, f2, d2, f3, d3):
+            """Reveal the first hidden LoRA slot; hide the button at 3/3.
+            Slider-row and dropdown visibility are recomputed from slot content
+            and the current model's library on every add, so a re-opened slot
+            can never inherit a stale visible state."""
+            vis = list(vis)
+            for i, v in enumerate(vis):
+                if not v:
+                    vis[i] = True
+                    break
+            srows = [gr.update(visible=bool(f or (d and d != _DD_NONE)))
+                     for f, d in ((f1, d1), (f2, d2), (f3, d3))]
+            return ([gr.update(visible=v) for v in vis] + srows
+                    + [gr.update(visible=not all(vis)), vis])
+
+        lora_add_btn.click(lora_add,
+                           inputs=[lora_vis, dit_dd]
+                           + [c for i in range(3)
+                              for c in lora_inputs[3 * i: 3 * i + 2]],
+                           outputs=lora_rows + lora_srows
+                           + [lora_add_btn, lora_vis]
+                           ).then(_sync_dd_vis, inputs=[dit_dd], outputs=lora_dds
+                           ).then(None, js=_JS_FIX_SLIDERS)
+
+        def _lora_remove(idx):
+            def _rm(vis):
+                vis = list(vis)
+                vis[idx] = False
+                return ([gr.update(visible=v) for v in vis]
+                        + [gr.update(visible=True), vis,
+                           # reset the slot: file, dropdown, strength (srow hidden)
+                           None, gr.update(value=_DD_NONE), 1.0,
+                           gr.update(visible=False)])
+            _rm.__name__ = f"lora_remove_{idx + 1}"
+            return _rm
+        for _idx, _btn in enumerate(lora_rm_btns):
+            _btn.click(_lora_remove(_idx), inputs=[lora_vis],
+                       outputs=lora_rows + [lora_add_btn, lora_vis]
+                       + lora_inputs[3 * _idx: 3 * _idx + 3]
+                       + [lora_srows[_idx]])
+
+        # A slot's strength slider appears once an adapter is loaded — via file
+        # drop OR dropdown pick — and the two sources are exclusive (loading one
+        # resets the other). All three events are user-driven (upload/clear/input),
+        # so the programmatic resets here can't loop.
+        def _lora_wire_slot(idx):
+            lf, ld, srow = lora_files[idx], lora_dds[idx], lora_srows[idx]
+
+            def _up(f):
+                return gr.update(visible=bool(f)), gr.update(value=_DD_NONE)
+            _up.__name__ = f"lora_file_{idx + 1}"
+            lf.upload(_up, inputs=[lf], outputs=[srow, ld]
+                      ).then(None, js=_JS_FIX_SLIDERS)
+
+            def _cl(dd):
+                return gr.update(visible=bool(dd and dd != _DD_NONE))
+            _cl.__name__ = f"lora_file_clear_{idx + 1}"
+            lf.clear(_cl, inputs=[ld], outputs=[srow])
+
+            def _pick(dd, f):
+                loaded = bool(dd and dd != _DD_NONE)
+                return (gr.update(visible=loaded or bool(f)),
+                        gr.update(value=None) if loaded else gr.update())
+            _pick.__name__ = f"lora_pick_{idx + 1}"
+            ld.input(_pick, inputs=[ld, lf], outputs=[srow, lf]
+                     ).then(None, js=_JS_FIX_SLIDERS)
+        for _idx in range(3):
+            _lora_wire_slot(_idx)
+
+        ctrl_inputs = [dit_dd, precision_dd, decoder_dd, prompt, negative_prompt,
+                       seconds, steps, seed, cfg, apg, sigma_global,
+                       sigma_slider, a2a_audio, inpaint_audio,
+                       inp_start, inp_end, output_opts, file_format] + lora_inputs
+        main_outputs = [output_player, timing, error_box, queued_html, history_html, st]
+
+        # NB: _present returns (player, timing, err, history, queued, state) —
+        # map onto components in that order.
+        def _reorder(fn):
+            def wrapped(*args):
+                player, tim, err_, hist, queued, state = fn(*args)
+                return player, tim, err_, queued, hist, state
+            wrapped.__name__ = fn.__name__
+            return wrapped
+
+        generate_btn.click(_reorder(generate), inputs=ctrl_inputs + [st],
+                           outputs=main_outputs
+                           ).then(pregen, inputs=ctrl_inputs + [st],
+                                  outputs=[queued_html, st])
+        promote_btn.click(_reorder(promote), inputs=ctrl_inputs + [st],
+                          outputs=main_outputs
+                          ).then(pregen, inputs=ctrl_inputs + [st],
+                                 outputs=[queued_html, st])
+
+        gr.Markdown(
+            "<p style='color:#888; font-size:0.85em'>"
+            "WAVs saved under <code>output/gradio/</code>. "
+            "Models run on CPU (XNNPACK). Precision applies to the DiT + codec "
+            "(+ encoder for a2a/inpaint); T5Gemma is fp16.</p>"
+        )
+
+    # gradio 6 moved `css` from the Blocks constructor to launch().
+    demo.queue(max_size=16).launch(share=share, server_name="0.0.0.0",
+                                   server_port=server_port, css=_css,
+                                   allowed_paths=[str(OUTPUT_DIR)],
+                                   prevent_thread_lock=False, show_error=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dit", choices=list(DIT_REL.keys()), default="sm-music",
+                    help="Initial DiT bundle (switchable at runtime)")
+    ap.add_argument("--decoder", choices=list(DEC_REL.keys()), default=None,
+                    help="Initial decoder. Default: pairs with --dit")
+    ap.add_argument("--precision", choices=list(PRECISIONS), default="fp32",
+                    help="Initial precision (switchable at runtime): fp32 (default, "
+                         "CPU fast+accurate) | w16a32 (fp16, ≈lossless, half size) | "
+                         "w8a32 / w8a8-dyn (GPTQ int8, ¼ size)")
+    ap.add_argument("--default-seconds", type=float, default=30.0,
+                    help="Length to pre-warm the initial DiT at")
+    ap.add_argument("--default-steps", type=int, default=8)
+    ap.add_argument("--threads", type=int, default=8, help="XNNPACK CPU threads")
+    ap.add_argument("--port", type=int, default=None,
+                    help="Server port (default: gradio picks 7860+, auto-incrementing)")
+    ap.add_argument("--share", action=argparse.BooleanOptionalAction, default=True,
+                    help="Create a public gradio.live URL (default on)")
+    args = ap.parse_args()
+
+    if args.decoder is None:
+        args.decoder = DEFAULT_DECODERS[args.dit]
+
+    global _THREADS
+    _THREADS = args.threads
+
+    print(f"\n━━━ SA3 TFLite — gradio ━━━")
+    print(f"  initial dit:      {args.dit}")
+    print(f"  initial decoder:  {args.decoder}")
+    print(f"  initial precision:{args.precision}")
+    print(f"  threads:          {args.threads}")
+    print(f"  models:           {', '.join(DIT_REL.keys())}  (runtime-switchable)")
+    build_ui(args.dit, args.decoder, args.precision, share=args.share,
+             default_seconds=args.default_seconds, default_steps=args.default_steps,
+             server_port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/optimized/tflite/scripts/sa3_tflite.py
+++ b/optimized/tflite/scripts/sa3_tflite.py
@@ -540,6 +540,22 @@ def main():
                          "inpainting only). Latent PSNR vs fp32 (same-s/same-l): "
                          "w16a32 ≈lossless (66/71 dB), w8a32 (GPTQ) 36/46 dB, "
                          "w8a8-dyn 24/30 dB.")
+    # LoRA (merged into the DiT weights at load; mirrors the MLX CLI's --lora)
+    ap.add_argument("--lora", action="append", nargs="+", default=None,
+                    metavar=("ADAPTER", "strength=S"),
+                    help="A LoRA adapter to merge into the DiT — repeat the flag to stack "
+                         "several. Each --lora takes the adapter path followed by an optional "
+                         "strength=S (default --lora-strength). Example: "
+                         "--lora plini.safetensors strength=0.8 . The adapter is a .safetensors "
+                         "file (SA3-native train_lora.py / underfit output) or a PEFT adapter "
+                         "directory; ONLY .safetensors is accepted. The merged weights are "
+                         "written into a cached copy of the DiT (models/tflite/lora_cache/) and "
+                         "reused on repeat runs. Requires --dit-precision fp32 or w16a32 "
+                         "(quantized-int8 DiTs can't be LoRA-merged). NOTE: per-step gating "
+                         "(steps=) is MLX-only — the frozen TFLite graph merges once at load.")
+    ap.add_argument("--lora-strength", type=float, default=1.0,
+                    help="Default strength for --lora adapters without their own strength= "
+                         "(default 1.0). 0 disables (bit-identical to no LoRA); >1 amplifies.")
     # Sampling
     ap.add_argument("--seconds", type=float, default=30.0,
                     help="Output length. T_lat = ceil(seconds*44100/4096) (natural ceil, decoder-"
@@ -583,6 +599,15 @@ def main():
     args.decoder_precision = args.decoder_precision or args.precision
     args.encoder_precision = args.encoder_precision or args.precision
 
+    # Parse --lora specs up front (fail fast, before any model work).
+    args.lora_specs = None
+    if args.lora:
+        from lora_core import parse_lora_spec, LoraError
+        try:
+            args.lora_specs = [parse_lora_spec(toks, args.lora_strength) for toks in args.lora]
+        except LoraError as e:
+            ap.error(str(e))
+
     # Interactive fills (match MLX/TRT).
     args = prompt_user_if_missing(args)
     if args.prompt is None:
@@ -606,7 +631,12 @@ def main():
             prec_tag = "" if args.precision == "fp32" else f"_{args.precision}"
         else:
             prec_tag = f"_dit-{args.dit_precision}_dec-{args.decoder_precision}"
-        args.out = f"{slug}{prec_tag}_{args.seed}.wav"
+        lora_tag = ""
+        if args.lora_specs:
+            names = "-".join(re.sub(r'[^a-z0-9]+', '', Path(s["path"]).stem.lower())[:12]
+                             for s in args.lora_specs)
+            lora_tag = f"_lora-{names}"
+        args.out = f"{slug}{prec_tag}{lora_tag}_{args.seed}.wav"
     out_path = Path(args.out)
     if not out_path.is_absolute() and out_path.parts[:1] != ("output",):
         out_path = REPO / "output" / out_path
@@ -666,6 +696,12 @@ def main():
     if args.cfg != 1.0:
         cfg_line += dim(f"  (apg={args.apg}, {'batched' if args.cfg_batched else 'sequential'} CFG)")
     print(cfg_line)
+    if args.lora_specs:
+        lora_disp = ", ".join(
+            os.path.basename(s["path"].rstrip("/"))
+            + (f"×{s['strength']:g}" if s["strength"] != 1.0 else "")
+            for s in args.lora_specs)
+        print(f"  {k('lora')}  {magenta(lora_disp)}")
     print(f"  {k('seconds')}  {args.seconds}s   {k('steps')}  {args.steps}   {k('seed')}  {args.seed}")
     print(f"  {k('T_lat')}  {T_lat} {dim(f'({target_dur:.2f}s → trimmed to {args.seconds:.2f}s)')}")
     print()
@@ -751,7 +787,16 @@ def main():
     cfg_note = (("CFG batched (1× batch=2 invoke/step)" if args.cfg_batched
                  else "CFG sequential (2× batch=1 invokes/step)") if args.cfg != 1.0 else "")
     print(f"        {dim('loading baked DiT ' + args.dit + ' ...')}", flush=True)
-    backend = BakedDiT(ensure_local(dit_rel(args.dit, args.dit_precision)), T_lat, t5_hidden, mask.astype(np.float32),
+    dit_path = ensure_local(dit_rel(args.dit, args.dit_precision))
+    if args.lora_specs:
+        from lora_patch import get_patched_dit
+        from lora_core import LoraError
+        try:
+            dit_path = get_patched_dit(dit_path, args.lora_specs, family=args.dit,
+                                       precision=args.dit_precision, log=sub)
+        except LoraError as e:
+            sys.exit(f"error: {e}")
+    backend = BakedDiT(dit_path, T_lat, t5_hidden, mask.astype(np.float32),
                        args.seconds, args.threads, cfg=args.cfg, apg=args.apg,
                        null_hidden=null_h, null_mask=null_m, local_add_cond=local_add_cond,
                        batched=args.cfg_batched)

--- a/optimized/tflite/scripts/sa3_tflite.py
+++ b/optimized/tflite/scripts/sa3_tflite.py
@@ -270,14 +270,6 @@ class BakedDiT:
                  cfg=1.0, apg=1.0, null_hidden=None, null_mask=None, local_add_cond=None,
                  batched=True):
         from ai_edge_litert import interpreter as tfl
-        self.L = L
-        self.cfg = float(cfg); self.apg = float(apg)
-        self.n_fwd = 0
-        # Batched CFG only applies when there's an uncond branch to co-batch (cfg != 1.0).
-        self.batched = bool(batched) and self.cfg != 1.0
-        B = 2 if self.batched else 1
-        self.B = B
-
         self.it = tfl.Interpreter(model_path=str(path), num_threads=threads)
         det = self.it.get_input_details()
         def pick(pred): return [d for d in det if pred(d)]
@@ -288,14 +280,41 @@ class BakedDiT:
         scalars = sorted(pick(lambda d: len(d["shape"]) == 1), key=lambda d: d["name"])
         self.i_t, self.i_sec = scalars[0], scalars[1]   # args_1=t < args_4=seconds by name
         self.out = self.it.get_output_details()[0]["index"]
+        # Track the currently-allocated (batch, length) so set_conditioning can skip the
+        # expensive resize+allocate when only the conditioning tensors change.
+        self._alloc_B = self._alloc_L = None
+        self.set_conditioning(L, t5_hidden, t5_mask, seconds, cfg=cfg, apg=apg,
+                              null_hidden=null_hidden, null_mask=null_mask,
+                              local_add_cond=local_add_cond, batched=batched)
+
+    def set_conditioning(self, L, t5_hidden, t5_mask, seconds, *, cfg=1.0, apg=1.0,
+                         null_hidden=None, null_mask=None, local_add_cond=None, batched=True):
+        """(Re)bind per-generation conditioning onto this (possibly reused) interpreter.
+
+        The baked DiT holds the conditioning (T5 hidden/mask, seconds, local_add_cond) as
+        RESIDENT input tensors — a fresh generation only changes those, not the graph. A
+        cached BakedDiT can therefore be re-pointed at a new prompt/length WITHOUT rebuilding
+        the interpreter or re-packing XNNPACK's weights: resize+allocate_tensors runs only
+        when the batch (cfg on/off) or length L actually changes, otherwise the residents are
+        overwritten in place (same reuse pattern BakedDecoder/BakedEncoder use for L). Called
+        from __init__ (so the CLI's one-shot path is unchanged) and by the gradio DiT cache."""
+        self.L = L
+        self.cfg = float(cfg); self.apg = float(apg)
+        self.n_fwd = 0
+        # Batched CFG only applies when there's an uncond branch to co-batch (cfg != 1.0).
+        self.batched = bool(batched) and self.cfg != 1.0
+        B = 2 if self.batched else 1
+        self.B = B
         # Resize batch axis to B (the canonical DiT is variable-batch) + length axis to L.
-        self.it.resize_tensor_input(self.i_x["index"],   [B, 256, L], strict=False)
-        self.it.resize_tensor_input(self.i_lac["index"], [B, 257, L], strict=False)
-        self.it.resize_tensor_input(self.i_t5h["index"], [B, COND_TOKENS, COND_DIM], strict=False)
-        self.it.resize_tensor_input(self.i_t5m["index"], [B, COND_TOKENS], strict=False)
-        self.it.resize_tensor_input(self.i_t["index"],   [B], strict=False)
-        self.it.resize_tensor_input(self.i_sec["index"], [B], strict=False)
-        self.it.allocate_tensors()
+        if (self._alloc_B, self._alloc_L) != (B, L):
+            self.it.resize_tensor_input(self.i_x["index"],   [B, 256, L], strict=False)
+            self.it.resize_tensor_input(self.i_lac["index"], [B, 257, L], strict=False)
+            self.it.resize_tensor_input(self.i_t5h["index"], [B, COND_TOKENS, COND_DIM], strict=False)
+            self.it.resize_tensor_input(self.i_t5m["index"], [B, COND_TOKENS], strict=False)
+            self.it.resize_tensor_input(self.i_t["index"],   [B], strict=False)
+            self.it.resize_tensor_input(self.i_sec["index"], [B], strict=False)
+            self.it.allocate_tensors()
+            self._alloc_B, self._alloc_L = B, L
 
         t5h = t5_hidden.astype(np.float32)
         t5m = t5_mask.astype(np.float32)
@@ -315,6 +334,7 @@ class BakedDiT:
             self.t5h, self.t5m = t5h, t5m
             self.it.set_tensor(self.i_sec["index"], sec)   # seconds + lac constant → resident
             self.it.set_tensor(self.i_lac["index"], lac)
+        return self
 
     def _fwd(self, x, t, t5h, t5m):
         """One batch=1 invoke (cfg==1.0 or sequential CFG)."""

--- a/optimized/tflite/scripts/spec.py
+++ b/optimized/tflite/scripts/spec.py
@@ -1,0 +1,180 @@
+"""Mel-spectrogram renderer — numpy-only port of the TensorRT release's spec.py.
+
+Same algorithm and constants as optimized/tensorRT/scripts/spec.py (the 3-band
+tinted stereo mel spectrogram from our run dashboards), with the torch pieces
+(STFT, resample, filterbank matmul) rewritten in numpy so the MLX release stays
+torch-free. Numerics match: periodic Hann window, center=True reflect padding,
+Slaney mel scale, librosa-compatible filterbank, linear resample with
+align_corners=False sampling positions.
+
+Exposes render_spectrogram_png(pcm_int16, sample_rate, width, height).
+"""
+from __future__ import annotations
+import io
+import math
+from functools import lru_cache
+
+import numpy as np
+from PIL import Image
+
+
+# 3-band tint
+SPEC_BANDS = [
+    (0, 200, (1.0, 0.0, 0.0)),       # Bass -> Red
+    (200, 1500, (0.0, 1.0, 0.0)),    # Mid  -> Green
+    (1500, 16000, (0.0, 0.0, 1.0)),  # High -> Blue
+]
+_BAND_COLORS = np.array([c for _, _, c in SPEC_BANDS], dtype=np.float32)
+
+# Slaney mel-scale constants (linear below 1 kHz, log above), matches librosa default.
+_F_SP = 200.0 / 3
+_MIN_LOG_HZ = 1000.0
+_MIN_LOG_MEL = _MIN_LOG_HZ / _F_SP
+_LOGSTEP = math.log(6.4) / 27.0
+
+
+def _hz_to_mel(hz):
+    hz = np.asarray(hz, dtype=np.float64)
+    log_term = np.log(np.maximum(hz, _MIN_LOG_HZ) / _MIN_LOG_HZ) / _LOGSTEP
+    return np.where(hz >= _MIN_LOG_HZ, _MIN_LOG_MEL + log_term, hz / _F_SP)
+
+
+def _mel_to_hz(mels):
+    mels = np.asarray(mels, dtype=np.float64)
+    return np.where(mels >= _MIN_LOG_MEL,
+                    _MIN_LOG_HZ * np.exp(_LOGSTEP * (mels - _MIN_LOG_MEL)),
+                    _F_SP * mels)
+
+
+def _mel_frequencies(n_mels, fmax, fmin=0.0):
+    return _mel_to_hz(np.linspace(_hz_to_mel(fmin), _hz_to_mel(fmax), n_mels))
+
+
+@lru_cache(maxsize=8)
+def _mel_filterbank(n_mels, n_fft, sr, fmax):
+    pts = _mel_to_hz(np.linspace(_hz_to_mel(0.0), _hz_to_mel(fmax), n_mels + 2))
+    fft_f = np.linspace(0, sr / 2, n_fft // 2 + 1)
+    filt = np.zeros((n_mels, n_fft // 2 + 1), dtype=np.float32)
+    for i in range(n_mels):
+        lo, ce, hi = pts[i], pts[i + 1], pts[i + 2]
+        left = (fft_f - lo) / max(ce - lo, 1e-10)
+        right = (hi - fft_f) / max(hi - ce, 1e-10)
+        filt[i] = np.maximum(0, np.minimum(left, right))
+    enorm = (2.0 / (pts[2:n_mels + 2] - pts[0:n_mels])).astype(np.float32)
+    filt *= enorm[:, None]
+    return filt
+
+
+def _stft_power(y, n_fft, hop):
+    """|STFT|^2 with periodic Hann + center=True reflect pad (torch.stft-compatible).
+    Returns (n_fft//2+1, n_frames) float32."""
+    y = np.asarray(y, dtype=np.float32)
+    pad = n_fft // 2
+    y = np.pad(y, pad, mode="reflect")
+    n_frames = 1 + (len(y) - n_fft) // hop
+    idx = np.arange(n_fft)[None, :] + hop * np.arange(n_frames)[:, None]
+    # periodic Hann (torch.hann_window default), not numpy's symmetric hanning
+    win = (0.5 - 0.5 * np.cos(2.0 * np.pi * np.arange(n_fft) / n_fft)).astype(np.float32)
+    frames = y[idx] * win[None, :]
+    spec = np.fft.rfft(frames, n=n_fft, axis=1)
+    return (spec.real ** 2 + spec.imag ** 2).T.astype(np.float32)
+
+
+def _melspectrogram(y_ch, sr, n_mels=30, fmax=16000, hop_length=2048, n_fft=2048):
+    power = _stft_power(y_ch, n_fft, hop_length)
+    return _mel_filterbank(n_mels, n_fft, sr, fmax) @ power
+
+
+def _power_to_db(S, top_db=80.0):
+    log_spec = 10.0 * np.log10(np.maximum(S, 1e-10))
+    return np.maximum(log_spec - log_spec.max(), -top_db)
+
+
+def _mel_channel(y_ch, sr, n_mels=30):
+    """dB-scaled mel + band-tinted RGB for one mono channel."""
+    S = _melspectrogram(y_ch, sr, n_mels=n_mels, fmax=16000, hop_length=2048)
+
+    S_db = _power_to_db(S)
+    np.clip(S_db, -60, 0, out=S_db)
+    S_db += 60.0
+    S_db /= 60.0
+    np.power(S_db, 0.6, out=S_db)
+
+    mel_f = _mel_frequencies(n_mels, fmax=16000)
+    n_frames = S.shape[1]
+    band_norms = np.empty((3, n_frames), dtype=np.float32)
+    for i, (flo, fhi, _) in enumerate(SPEC_BANDS):
+        mask = (mel_f >= flo) & (mel_f < fhi)
+        if mask.any():
+            power = np.sum(S[mask], axis=0)
+            db = 10.0 * np.log10(power + 1e-10)
+            np.clip(db, -20, None, out=db)
+            db -= -20
+            mx = db.max()
+            if mx > 0:
+                db /= mx
+            band_norms[i] = db
+        else:
+            band_norms[i] = 0.0
+
+    rgb = band_norms.T @ _BAND_COLORS
+    for c in range(3):
+        mx = rgb[:, c].max()
+        if mx > 0:
+            rgb[:, c] /= mx
+
+    return S_db, rgb
+
+
+def _resample_to_32k(pcm_int16, sr_in):
+    """Resample (T, 2) int16 PCM to (2, T') float32 at 32 kHz.
+    Linear interpolation at align_corners=False sample positions (matches the
+    torch.nn.functional.interpolate call in the TRT original)."""
+    target_sr = 32000
+    y = pcm_int16.astype(np.float32).T / 32768.0      # (2, T)
+    if sr_in == target_sr:
+        return y, target_sr
+    in_len = y.shape[-1]
+    new_len = int(round(in_len * target_sr / sr_in))
+    scale = in_len / new_len
+    pos = np.clip((np.arange(new_len, dtype=np.float64) + 0.5) * scale - 0.5, 0, in_len - 1)
+    out = np.stack([np.interp(pos, np.arange(in_len), ch) for ch in y]).astype(np.float32)
+    return out, target_sr
+
+
+def render_spectrogram_png(pcm_int16, sample_rate=44100, width=1200, height=240,
+                           n_mels=30) -> bytes:
+    """Render the 3-band tinted stereo mel spectrogram to PNG bytes.
+
+    Args:
+        pcm_int16: (T, 2) int16 numpy array — stereo PCM.
+        sample_rate: input PCM sample rate (default 44100).
+        width, height: final image size.
+        n_mels: mel filterbank size (30 matches the dashboards).
+
+    Returns: PNG bytes ready to base64 / save / etc.
+    """
+    if pcm_int16.ndim != 2 or pcm_int16.shape[1] != 2:
+        raise ValueError(f"expected (T, 2) PCM, got {pcm_int16.shape}")
+    y, sr = _resample_to_32k(pcm_int16, sample_rate)
+    S_L, rgb_L = _mel_channel(y[0], sr, n_mels=n_mels)
+    S_R, rgb_R = _mel_channel(y[1], sr, n_mels=n_mels)
+
+    nf = min(S_L.shape[1], S_R.shape[1])
+    S_L, S_R = S_L[:, :nf], S_R[:, :nf]
+    rgb_L, rgb_R = rgb_L[:nf], rgb_R[:nf]
+    nm = S_L.shape[0]
+
+    # L channel: flip vertically so bass-band is at bottom.
+    S_L = S_L[::-1]
+
+    img = np.empty((nm * 2, nf, 3), dtype=np.float32)
+    img[:nm] = S_L[:, :, np.newaxis] * rgb_L[np.newaxis, :, :]
+    img[nm:] = S_R[:, :, np.newaxis] * rgb_R[np.newaxis, :, :]
+
+    np.clip(img, 0, 1, out=img)
+    img *= 255
+    pil = Image.fromarray(img.astype(np.uint8)).resize((width, height), Image.LANCZOS)
+    buf = io.BytesIO()
+    pil.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()

--- a/optimized/tflite/scripts/test_lora_patch.py
+++ b/optimized/tflite/scripts/test_lora_patch.py
@@ -1,0 +1,301 @@
+"""Tests for the TFLite LoRA merge (lora_core.py + lora_patch.py).
+
+Stdlib unittest, no torch / no mlx / no pytest (matches test_windows_compat.py).
+Two tiers:
+  * CI-safe: safetensors reader, per-type merge math (independent re-derivation),
+    spec parser, quantized-precision refusal — no model files needed.
+  * Model-dependent (skipped unless a local DiT .tflite is present): the real
+    plini adapter's 169/169 name-mapping bijection on medium; w16a32 fp16
+    buffer discovery; and a synthetic FULL-target-set adapter on sm-music that
+    exercises every mapping tier + the clone/patch/read-back path.
+
+Run:  python scripts/test_lora_patch.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+import lora_core as lc  # noqa: E402
+
+# Local model paths (present on a dev box with the tflite bundle installed;
+# absent in CI → the model-dependent tests skip). SA3_TFLITE_MODELS_DIR
+# overrides the location (e.g. pointing a worktree's tests at the main checkout).
+_CHECKOUT = os.environ.get(
+    "SA3_TFLITE_MODELS_DIR",
+    os.path.abspath(os.path.join(_HERE, "..", "models", "tflite")))
+_MODELS = {
+    ("sm-music", "fp32"): f"{_CHECKOUT}/sa3-sm-music/dit_fp32.tflite",
+    ("sm-music", "w16a32"): f"{_CHECKOUT}/sa3-sm-music/dit_w16a32.tflite",
+    ("medium", "fp32"): f"{_CHECKOUT}/sa3-m/dit_fp32.tflite",
+    ("sm-music", "w8a32"): f"{_CHECKOUT}/sa3-sm-music/dit_w8a32.tflite",
+}
+_PLINI = "/Users/cj/clod/speed-metal/scripts/lora_bench/plini-sa3-380.safetensors"
+
+
+def _have(key):
+    p = _MODELS.get(key)
+    return p and os.path.exists(p)
+
+
+def _save_native_safetensors(path, layers, cfg):
+    """Write a minimal SA3-native adapter: {layer.parametrizations.weight.0.param}."""
+    tensors, blob, hdr = {}, bytearray(), {}
+    for layer, params in layers.items():
+        for pname, arr in params.items():
+            tensors[f"{layer}.parametrizations.weight.0.{pname}"] = np.ascontiguousarray(arr, np.float32)
+    for k, v in tensors.items():
+        off = len(blob)
+        blob += v.tobytes()
+        hdr[k] = {"dtype": "F32", "shape": list(v.shape), "data_offsets": [off, len(blob)]}
+    hdr["__metadata__"] = {"lora_config": json.dumps(cfg)}
+    hbytes = json.dumps(hdr).encode()
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(hbytes)))
+        f.write(hbytes)
+        f.write(blob)
+
+
+# ── CI-safe unit tests ─────────────────────────────────────────────────────────
+
+class TestSafetensorsReader(unittest.TestCase):
+    def test_roundtrip_fp32_and_metadata(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "a.safetensors")
+            A = np.random.default_rng(0).standard_normal((4, 8)).astype(np.float32)
+            _save_native_safetensors(p, {"foo": {"lora_A": A, "lora_B": np.zeros((6, 4), np.float32)}},
+                                     {"adapter_type": "lora", "rank": 4, "alpha": 4})
+            t, meta = lc._load_safetensors(p)
+            self.assertIn("foo.parametrizations.weight.0.lora_A", t)
+            np.testing.assert_array_equal(t["foo.parametrizations.weight.0.lora_A"], A)
+            self.assertEqual(json.loads(meta["lora_config"])["adapter_type"], "lora")
+
+    def test_pickle_refused(self):
+        for bad in ("evil.ckpt", "evil.pt", "evil.bin", "x.npz"):
+            with self.assertRaises(lc.LoraError):
+                lc._load_safetensors(bad)
+
+
+class TestMergeMath(unittest.TestCase):
+    """Independent re-derivation of the four core types (guards the copy)."""
+
+    def setUp(self):
+        self.rng = np.random.default_rng(1)
+        self.W0 = self.rng.standard_normal((6, 8)).astype(np.float32)
+
+    def _p(self, t, r=3):
+        p = {}
+        if not t.endswith("-xs"):
+            p["lora_A"] = self.rng.standard_normal((r, 8)).astype(np.float32)
+            p["lora_B"] = self.rng.standard_normal((6, r)).astype(np.float32)
+        else:
+            p["M_xs"] = self.rng.standard_normal((r, r)).astype(np.float32)
+        if "magnitude" in lc._PARAMS_FOR[t]:
+            p["magnitude"] = np.linalg.norm(self.W0, axis=1 if "rows" in t else 0).astype(np.float32)
+        if "magnitude_r" in lc._PARAMS_FOR[t]:
+            p["magnitude_r"] = np.linalg.norm(self.W0, axis=1).astype(np.float32)
+            p["magnitude_c"] = np.linalg.norm(self.W0, axis=0).astype(np.float32)
+        return p
+
+    def test_lora(self):
+        p = self._p("lora")
+        ref = self.W0 + 2.0 * (p["lora_B"] @ p["lora_A"])
+        np.testing.assert_allclose(lc.merged_weight(self.W0, p, "lora", 2.0), ref, atol=1e-5)
+
+    def test_dora_rows(self):
+        p = self._p("dora-rows")
+        V = self.W0 + 1.0 * (p["lora_B"] @ p["lora_A"])
+        ref = V / (np.linalg.norm(V, axis=1, keepdims=True) + 1e-12) * p["magnitude"].reshape(-1, 1)
+        np.testing.assert_allclose(lc.merged_weight(self.W0, p, "dora-rows", 1.0), ref, atol=1e-5)
+
+    def test_dora_cols(self):
+        p = self._p("dora-cols")
+        V = self.W0 + 1.0 * (p["lora_B"] @ p["lora_A"])
+        ref = V / (np.linalg.norm(V, axis=0, keepdims=True) + 1e-12) * p["magnitude"].reshape(1, -1)
+        np.testing.assert_allclose(lc.merged_weight(self.W0, p, "dora-cols", 1.0), ref, atol=1e-5)
+
+    def test_all_types_finite_and_shaped(self):
+        for t in lc._PARAMS_FOR:
+            p = self._p(t)
+            lc.check_shapes("x", self.W0, p, t)
+            W = lc.merged_weight(self.W0, p, t, 1.0)
+            self.assertEqual(W.shape, self.W0.shape)
+            self.assertTrue(np.isfinite(W).all(), t)
+
+    def test_shape_mismatch_raises(self):
+        p = {"lora_A": np.zeros((3, 99), np.float32), "lora_B": np.zeros((6, 3), np.float32)}
+        with self.assertRaises(lc.LoraError):
+            lc.check_shapes("x", self.W0, p, "lora")
+
+
+class TestSpecParser(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(lc.parse_lora_spec(["a.safetensors"])["strength"], 1.0)
+        self.assertEqual(lc.parse_lora_spec(["a.safetensors", "strength=0.7"])["strength"], 0.7)
+
+    def test_steps_rejected_points_to_mlx(self):
+        with self.assertRaises(lc.LoraError) as cm:
+            lc.parse_lora_spec(["a.safetensors", "steps=2-8"])
+        self.assertIn("MLX", str(cm.exception))
+
+    def test_bad_tokens(self):
+        for bad in (["a", "b.st"], ["a", "strength=x"], []):
+            with self.assertRaises(lc.LoraError):
+                lc.parse_lora_spec(bad)
+
+
+class TestQuantizedRefusal(unittest.TestCase):
+    def test_precision_refused_before_touching_files(self):
+        import lora_patch as lp
+        for prec in ("w8a32", "w8a8-dyn", "w4a32"):
+            with self.assertRaises(lc.LoraError) as cm:
+                lp.get_patched_dit("/nonexistent.tflite", [{"path": "x", "strength": 1.0}],
+                                   family="medium", precision=prec, log=lambda _m: None)
+            self.assertIn(prec, str(cm.exception))
+
+
+# ── model-dependent tests ────────────────────────────────────────────────────
+
+@unittest.skipUnless(_have(("medium", "fp32")) and os.path.exists(_PLINI),
+                     "medium fp32 DiT + plini adapter not present")
+class TestRealAdapterMapping(unittest.TestCase):
+    def test_plini_169_bijection_on_medium(self):
+        import mmap
+        import lora_patch as lp
+        f = open(_MODELS[("medium", "fp32")], "rb")
+        buf = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+        try:
+            mapper = lp._Mapper(list(lp._fc_weight_buffers(buf)))
+            _at, _sc, layers = lc.parse_adapter(_PLINI)
+            offs = set()
+            for layer, p in layers.items():
+                want = (p["lora_B"].shape[0], p["lora_A"].shape[1])
+                rec = mapper.resolve(layer, want)
+                self.assertEqual(rec["shape"], want, layer)
+                offs.add(rec["off"])
+            self.assertEqual(len(layers), 169)
+            self.assertEqual(len(offs), 169, "buffer offsets must be unique (no collisions)")
+        finally:
+            del mapper
+            buf.close()
+            f.close()
+
+
+@unittest.skipUnless(_have(("sm-music", "w16a32")), "sm-music w16a32 DiT not present")
+class TestW16A32Discovery(unittest.TestCase):
+    def test_all_weights_fp16_via_dequant(self):
+        import mmap
+        import lora_patch as lp
+        f = open(_MODELS[("sm-music", "w16a32")], "rb")
+        buf = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+        try:
+            fcs = list(lp._fc_weight_buffers(buf))
+            self.assertGreater(len(fcs), 100)
+            self.assertTrue(all(np.dtype(r["np_dtype"]) == np.float16 for r in fcs))
+            self.assertTrue(any(r["shape"] == (768, 256) for r in fcs), "seconds cond present")
+        finally:
+            del fcs
+            buf.close()
+            f.close()
+
+
+@unittest.skipUnless(_have(("sm-music", "fp32")), "sm-music fp32 DiT not present")
+class TestFullSetPatchRoundTrip(unittest.TestCase):
+    """Synthetic all-target adapter (every mapping tier) → clone + patch +
+    byte-exact read-back on the smaller sm-music fp32 model."""
+
+    def test_map_patch_readback(self):
+        import mmap
+        import lora_patch as lp
+        base = _MODELS[("sm-music", "fp32")]
+        f = open(base, "rb")
+        buf = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+        fcs = list(lp._fc_weight_buffers(buf))
+        mapper = lp._Mapper(fcs)
+
+        # Inverse-classify each FC → a checkpoint layer name, so we can build a
+        # synthetic adapter that targets every tier (block linears, local_embed,
+        # singleton embedders, seconds cond).
+        ckpt_for = {}  # off -> (ckpt_layer_name, (fan_out, fan_in))
+        # tier 1
+        rev_block = {("self_attn", "to_qkv", False): "self_attn.to_qkv",
+                     ("self_attn", "to_out", False): "self_attn.to_out",
+                     ("cross_attn", "to_q", False): "cross_attn.to_q",
+                     ("cross_attn", "to_kv", False): "cross_attn.to_kv",
+                     ("cross_attn", "to_out", False): "cross_attn.to_out",
+                     ("ff", "proj", True): "ff.ff.0.proj", ("ff", "2", False): "ff.ff.2"}
+        for (blk, mod, leaf, glu), rec in mapper._block.items():
+            ckpt_for[rec["off"]] = (f"model.transformer.layers.{blk}.{rev_block[(mod, leaf, glu)]}", rec["shape"])
+        # tier 2 (topological rank == block)
+        for leaf, recs in mapper._local.items():
+            for blk, rec in enumerate(recs):
+                ckpt_for[rec["off"]] = (f"model.transformer.layers.{blk}.to_local_embed.seq.{leaf}", rec["shape"])
+        # tier 3 singletons
+        for ckpt, sub in lp._SINGLETON_CKPT.items():
+            hit = [r for r in fcs if sub in r["name"]]
+            if hit:
+                ckpt_for[hit[0]["off"]] = (ckpt, hit[0]["shape"])
+        # tier 4 seconds cond
+        if mapper._seconds:
+            ckpt_for[mapper._seconds[0]["off"]] = (lc.COND_SECONDS_LAYER, mapper._seconds[0]["shape"])
+
+        rng = np.random.default_rng(7)
+        layers = {}
+        for off, (name, (fo, fi)) in ckpt_for.items():
+            r = 4
+            layers[name] = {
+                "lora_A": (rng.standard_normal((r, fi)) * 0.01).astype(np.float32),
+                "lora_B": (rng.standard_normal((fo, r)) * 0.01).astype(np.float32),
+                "magnitude": np.linalg.norm(
+                    rng.standard_normal((fo, fi)).astype(np.float32), axis=1).astype(np.float32),
+            }
+        buf.close()
+        f.close()
+
+        with tempfile.TemporaryDirectory() as d:
+            adapter = os.path.join(d, "full.safetensors")
+            _save_native_safetensors(adapter, layers,
+                                     {"adapter_type": "dora-rows", "rank": 4, "alpha": 4})
+            specs = [lc.parse_lora_spec([adapter, "strength=0.5"])]
+            out = lp.get_patched_dit(base, specs, family="sm-music", precision="fp32",
+                                     cache_dir=os.path.join(d, "cache"), log=lambda _m: None)
+            self.assertTrue(out.exists())
+
+            # read-back: every patched buffer == fp32(W0 + 0.5*(merged-W0))
+            fb = open(base, "rb"); bb = mmap.mmap(fb.fileno(), 0, access=mmap.ACCESS_READ)
+            fo2 = open(out, "rb"); bo = mmap.mmap(fo2.fileno(), 0, access=mmap.ACCESS_READ)
+            def owned(mm, off, size, dt):
+                # copy out of the mmap so no view keeps it open at close time
+                return np.array(np.frombuffer(mm, dt, count=size // np.dtype(dt).itemsize,
+                                              offset=off))
+            m2 = lp._Mapper(list(lp._fc_weight_buffers(bb)))
+            checked = 0
+            for name, p in layers.items():
+                rec = m2.resolve(name, (p["lora_B"].shape[0], p["lora_A"].shape[1]))
+                W0 = owned(bb, rec["off"], rec["size"], np.float32).reshape(rec["shape"])
+                got = owned(bo, rec["off"], rec["size"], np.float32).reshape(rec["shape"])
+                ref = (W0 + 0.5 * (lc.merged_weight(W0, p, "dora-rows", 1.0) - W0)).astype(np.float32)
+                self.assertTrue(np.array_equal(got, ref), name)
+                checked += 1
+            self.assertEqual(checked, len(layers))
+            # a non-target FC — any FC not in our set — must be unchanged
+            untouched = [r for r in lp._fc_weight_buffers(bb) if r["off"] not in ckpt_for]
+            if untouched:
+                r = untouched[0]
+                self.assertTrue(np.array_equal(owned(bb, r["off"], r["size"], np.uint8),
+                                               owned(bo, r["off"], r["size"], np.uint8)),
+                                "untouched tensor changed")
+            del m2
+            bb.close(); bo.close(); fb.close(); fo2.close()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
LoRA inference **and** a browser UI for the CPU/TFLite route — bringing it to parity with the MLX backend.

## 1. LoRA inference (`--lora`)

Apply LoRA/DoRA/BoRA adapters to the baked DiT by merging them into its FULLY_CONNECTED weight buffers — the frozen-graph counterpart of the MLX merge-at-load. A `.tflite` has no weight dict to edit, so this patches the weight buffers on an APFS clone (`cp -c`, ~instant) *before* `Interpreter(...)`, so XNNPACK packs the merged weights at allocate with zero runtime cost; patched files are cached by content hash (adapter + strength), so repeat runs reuse them.

- `scripts/lora_core.py` — torch/mlx-free vendored copy of `optimized/mlx`'s merge math (all nine adapter types) with a numpy safetensors reader; keep-in-sync header points at the MLX source.
- `scripts/lora_patch.py` — FlatBuffer header parse → checkpoint-layer → FC-weight-buffer mapping (four tiers, all hard-fail on ambiguity), clone + exact-offset in-place patch, cache. fp32 (direct fp32 consts) and w16a32 (fp16 consts behind DEQUANTIZE) supported.
- `--lora` / `--lora-strength` on the CLI, mirroring the MLX flag (repeatable, `strength=`). `steps=` is rejected with a pointer to MLX — a frozen graph can't gate per-step.

Same adapters as the MLX backend (SA3-native / underfit / PEFT `.safetensors`; pickle refused). Verified: the real plini adapter maps 169/169 on medium; a synthetic full-target-set adapter clone/patches with byte-exact read-back on sm-music; base-vs-LoRA output genuinely differs. 14 unit tests (`scripts/test_lora_patch.py`; model-dependent ones skip without local models).

**Quantized-int8 DiTs (w8a32 / w8a8-dyn / w4a32) are refused for now** — their weights are GPTQ-calibrated int8, and a naive dequant→merge→requant would throw away the GPTQ error-feedback grid (a doubly-degraded model). Doing it well needs a GPTQ pass over the merged weights; documented as an open item. Use fp32/w16a32 (on CPU fp32 is the fast-and-accurate choice anyway).

## 2. Web UI (`./sa3-gradio`)

A full port of the MLX gradio to the TFLite backend — same UI: model/decoder pickers, CFG/negative/APG/sigma_max, audio-to-audio + inpainting, the spectrogram-as-player, the history panel, the playback options (auto-play, infinite radio with pre-generation, loop, hotswap), MP3/WAV save, per-model LoRA memory, and all the playback JS verbatim. Driven by the TFLite pipeline (Tokenizer / T5GemmaTFLite / BakedDiT / BakedDecoder / BakedEncoder / P.sample).

New vs the MLX gradio: a **Precision dropdown** (fp32 / w16a32 / w8a32 / w8a8-dyn) next to the model picker. The LoRA panel drops the per-step range (frozen graph) and disables under quantized precision. `BakedDiT.__init__` was refactored into `__init__` + `set_conditioning()` (behavior-preserving; the CLI one-shot path is unchanged) so the UI caches the DiT interpreter and re-binds conditioning per generation.

Verified in a real headless browser (CDP, 29/29 checks): generations through the UI at fp32 and w16a32, the precision→LoRA enable/disable flow, LoRA via the local-folder dropdown, model-switch rescans, spectrogram/history/playback all present. CLI regression-checked post-refactor.

## Notes
- `lora_core.py`'s merge math must stay in sync with `optimized/mlx/models/defs/lora_merge.py` (both mirror the torch `LoRAParametrization`).
- Cache + adapter library (`models/tflite/lora_cache/`, `loras/`, `output/`) are gitignored.
