### PR TITLE
tensorRT: bound the FP16-mixed RoPE island so the medium DiT's attention core fuses (4.3× @L=4096), and make fp16mixed the medium default

### DIFF
--- a/optimized/tensorRT/README.md
+++ b/optimized/tensorRT/README.md
@@ -119,28 +119,40 @@ Omit `--dit` / `--decoder` for an interactive arrow-key picker. Relative
 
 ### DiT precision (`--precision`)
 
-The default resolves per model — no flag needed for the recommended setup:
+`fp16mixed` is the default for every model — no flag needed for the recommended setup:
 
 | model            | default     | why                                                        |
 |------------------|-------------|------------------------------------------------------------|
-| `medium`         | `bf16`      | FMHA-fused (0 → 96 fused attention nodes) → **1.8× @256 / 4.7× @4096** vs fp16-mixed, within the perceptual floor |
+| `medium`         | `fp16mixed` | FMHA-fused (96 fused attention nodes) **and** fp32-accurate at every length |
 | `sm-music`/`sm-sfx` | `fp16mixed` | standard attention — already fuses in fp16-mixed           |
 
-`--precision` also takes `fp16mixed` and `fp32` explicitly:
+`--precision` also takes `bf16` (medium only) and `fp32` explicitly:
 
+- **`fp16mixed`** — canonical: FP16 trunk, FP32 islands around RMSNorm and RoPE
+  generation, and an FP16 attention core (QK^T → Softmax → P·V) so TRT's FMHA fuser
+  fires. Teacher-forced velocity cos **1.0000** vs the FP32 engine at every length.
+  Bit-reproducible run to run.
+  <br>Medium used to default to `bf16` because this engine's attention core was
+  stuck in FP32 and therefore unfused — 0 fused MHA nodes. Bounding the RoPE island
+  before QK^T fixed that (**4.3× faster at L=4096**), which retired the reason to
+  prefer `bf16`. Engines built before 2026-07 are the slow variant; rebuild with
+  `build_from_onnx.py sa3-m`.
 - **`bf16`** — *medium only.* Same `dit.onnx` as fp32, built with `BuilderFlag.BF16`;
-  bf16 carries fp32's range so the FP32-softmax islands vanish and TRT's FMHA fuser
-  fires. **Not seed-reproducible vs fp16-mixed** — the medium DiT uses *differential*
-  attention (cancellation-sensitive), so bf16 is a different-but-equal take per seed
-  (quality within the re-seed floor; exact samples differ). Same varlen profile
+  a uniform bf16 trunk also lets the FMHA fuser fire, and it is ~3% faster than
+  `fp16mixed`. **But it drifts at long sequence**: weakly-typed BF16 lets TRT
+  evaluate RoPE's rotation angle in bf16, and that angle reaches ~4155 rad at
+  L=4092 where bf16's spacing is 32 rad (bigger than a full 2π rotation), so
+  position information for the fast-rotating dims is destroyed. The latent inflates
+  ~2.5× over the 8 steps and a 6-minute render clips 2–3% of samples. Clean at short
+  lengths; use `fp16mixed` for anything long. Also **not seed-reproducible vs
+  fp16-mixed** — a different-but-equal take per seed. Same varlen profile
   (L 1..4096, opt 1292) and full mode/feature set as the other precisions.
-- **`fp16mixed`** — canonical FP16 trunk + FP32 islands. Bit-reproducible; use it when
-  you need exact per-seed reproducibility or max per-step fidelity.
 - **`fp32`** — pure FP32, bit-equivalent to PyTorch eager (~2× slower, ~2× VRAM).
 
 ```bash
-# medium defaults to bf16 (fast); force the reproducible engine instead:
-./sa3 --prompt "..." --dit medium --decoder same-l --precision fp16mixed
+# medium defaults to fp16mixed; the last ~3% of speed, at the cost of long-seq
+# accuracy, is opt-in:
+./sa3 --prompt "..." --dit medium --decoder same-l --precision bf16
 ```
 
 The TRT DiT engines are static batch=1 (the ONNX bakes batch=1), so CFG runs as a
@@ -165,7 +177,7 @@ variance once the graph is built).
 
 ```bash
 .venv/bin/python scripts/bench_dit_profile.py \
-    --engines "canonical=models/sm_90/sa3-sm-music/dit_bf16.trt" \
+    --engines "canonical=models/sm_90/sa3-sm-music/dit_fp16mixed.trt" \
     --lvals 1,32,128,256,512,1024,1292,2048,4096 --warmup 3 --runs 7
 ```
 
@@ -216,9 +228,9 @@ optimized/tensorRT/
 └── models/                      ← .trt engines (auto-downloaded per arch; ~8 GB)
     └── sm_<cc>/                 ← arch dir matches `nvidia-smi --query-gpu=compute_cap`
         ├── t5gemma/t5gemma_fp16mixed.trt
-        ├── sa3-sm-music/dit_bf16.trt
-        ├── sa3-sm-sfx/dit_bf16.trt
-        ├── sa3-m/dit_bf16.trt
+        ├── sa3-sm-music/dit_fp16mixed.trt
+        ├── sa3-sm-sfx/dit_fp16mixed.trt
+        ├── sa3-m/dit_fp16mixed.trt      ← + dit_bf16.trt / dit_fp32.trt if selected
         ├── same-s/{enc,dec}_dynamic_bf16.trt
         └── same-l/{enc,dec}_dynamic_triton_swa.trt
 ```
@@ -243,7 +255,8 @@ invocation per sampling step handles everything.
   specific cross-attention output token collapsed in magnitude.
 - **PCM-baked SAME-S decoder**: the int16 narrow + transpose are folded
   into the decoder engine itself; saves ~3 ms of post-decode CPU work.
-- **Mixed precision**: DiT runs BF16, decoder int32→int16, T5Gemma
+- **Mixed precision**: DiT runs FP16-mixed (FP16 trunk + FP32 RMSNorm/RoPE
+  islands + FMHA-fused FP16 attention core), decoder int32→int16, T5Gemma
   FP16-mixed. `--quiet` skips per-stage NVML probes for an extra ~4 ms.
 - **Auto-download**: missing engines are pulled from
   `stabilityai/stable-audio-3-optimized/tensorRT/sm_<cc>/` on first use.

--- a/optimized/tensorRT/build/README.md
+++ b/optimized/tensorRT/build/README.md
@@ -24,7 +24,7 @@ HuggingFace                    onnx/<engine>/  ←─────── publish 
                              no graphsurgeon)            build_same_*.py)
 ```
 
-The SA3 DiT ships both an FP32 canonical `dit.onnx` (regenerable from PyTorch source) and a pre-processed `dit_fp16mixed.onnx` (canonical + FP32 islands around RMSNorm / Softmax / RoPE, rest converted to FP16). Consumers use the pre-processed one; producers refresh both when the model retrains.
+The SA3 DiT ships both an FP32 canonical `dit.onnx` (regenerable from PyTorch source) and a pre-processed `dit_fp16mixed.onnx` (canonical + FP32 islands around RMSNorm and RoPE *generation*, FP16 attention core, rest converted to FP16). Consumers use the pre-processed one; producers refresh both when the model retrains.
 
 ## Consumer flow (default)
 
@@ -144,9 +144,13 @@ python build_dit_fp16mixed.py \
 # repeat for sa3-sm-sfx and sa3-m
 ```
 
-This wraps every RMSNorm chain, attention `Softmax`, and the RoPE region in `Cast(FP32) → op → Cast(FP16)` islands and converts the rest of the weights to FP16, then compiles a `STRONGLY_TYPED` TRT engine. It writes BOTH the modified `dit_fp16mixed.onnx` (~half the size of the original) AND the TRT engine. Publishing the modified ONNX is what lets consumers compile their own engines with plain `build_from_onnx.py` (no `onnx-graphsurgeon` dependency on the consumer side).
+This wraps every RMSNorm chain, attention `Softmax`, and the RoPE region in `Cast(FP32) → op → Cast(FP16)` islands, converts the rest of the weights to FP16, then **bounds the RoPE island before QK^T** (`bound_attention_core()`) so the attention core — QK^T → Softmax → P·V — runs FP16, and finally compiles a `STRONGLY_TYPED` TRT engine. It writes BOTH the modified `dit_fp16mixed.onnx` (~half the size of the original) AND the TRT engine. Publishing the modified ONNX is what lets consumers compile their own engines with plain `build_from_onnx.py` (no `onnx-graphsurgeon` dependency on the consumer side).
 
-Naive `BuilderFlag.FP16` (without the surgery) catastrophically overflows in RMSNorm variance + attention softmax — the islands are mandatory. BF16 was tried earlier and compounds quantisation error over 8 sampling steps (cos-sim drifts from 0.99 single-step to 0.81 final-latent vs PT FP32) — audibly degraded.
+The attention-core step is not cosmetic. Without it the RoPE island emits q/k in FP32 and nothing casts them back, so the whole O(L²) core stays FP32 and TRT's FMHA fuser cannot fire: **0 fused MHA nodes and 4.3× slower at L=4096** on the medium DiT, for no accuracy gain (teacher-forced velocity cos vs the FP32 engine is 1.0000 with the step, 0.9998 without). PyTorch does the same thing the step does — `apply_rotary_pos_emb` ends with `t.to(out_dtype)` and attention is then a fused `scaled_dot_product_attention` over FP16 inputs — and TRT's FMHA kernels accumulate softmax in FP32 internally anyway. `--no-bound-attn` skips it, only useful for reproducing the pre-2026-07 engines.
+
+`STRONGLY_TYPED` is **mandatory**, not stylistic. Building the same graph weakly-typed with `BuilderFlag.FP16` fuses just as well and runs just as fast, but the FP16 flag also lets TRT re-cast the FP32 RMSNorm islands — i.e. it silently degrades to naive FP16 (measured: teacher-forced cos 0.88 @L=256, 0.77 @L=4092). Note this is the opposite of the fp8-GEMM recipe, where weakly-typed is required; the rule is per-pattern.
+
+Naive `BuilderFlag.FP16` (without the surgery) catastrophically overflows in RMSNorm variance — the RMSNorm islands are mandatory. BF16 was tried earlier and is audibly degraded on long renders, but the mechanism is narrower than the "compounds quantisation error over 8 sampling steps" story recorded here previously: a per-op ablation showed bf16 arithmetic through the rest of the DiT is clean, and the single culprit is the **RoPE rotation angle**. `t · inv_freq` reaches ~4155 rad at L=4092, where bf16's spacing is 32 rad — larger than a full 2π rotation — so `cos`/`sin` of it carry no position information for the fast-rotating dims (9 of 16 frequency pairs destroyed). The latent then inflates ~2.5× over the 8 steps and the decoder clips 2–3% of samples. It is clean at short lengths. The general rule: **any Fourier or rotary feature whose angle can exceed ~2048 rad is unsafe in bf16 by construction** — that is where bf16's ULP first exceeds 2π.
 
 Each script also writes the ONNX to `<HF_REPO>/onnx/<engine>/<file>.onnx`. After all 8 are done:
 
@@ -165,7 +169,7 @@ git push
 | `build.py` | Interactive menu (default entry point) | consumer |
 | `build_from_onnx.py` | One target → download ONNX from HF + compile to TRT. **For the SA3 DiTs, pulls `dit_fp16mixed.onnx` (the pre-processed island-wrapped graph)** so the consumer just needs to invoke `STRONGLY_TYPED` compilation — no `onnx-graphsurgeon` required | consumer |
 | `build_dit_profile.py` | Build a DiT with custom `(min, opt, max)` profile shapes (experimental — short-form / fixed-shape variants). Operates on either ONNX flavor. | consumer |
-| `build_dit_fp16mixed.py` | **Producer-side** ONNX surgery: takes the canonical FP32 `dit.onnx`, finds RMSNorm chains + attention `Softmax` + RoPE region, wraps each in `Cast(FP32) ↔ Cast(FP16)` islands, converts non-island weights to FP16, and writes both the modified `dit_fp16mixed.onnx` AND the TRT engine. Only re-run when the model retrains or the island recipe changes. Requires `onnx` + `onnx-graphsurgeon`. | producer |
+| `build_dit_fp16mixed.py` | **Producer-side** ONNX surgery: takes the canonical FP32 `dit.onnx`, finds RMSNorm chains + attention `Softmax` + RoPE region, wraps each in `Cast(FP32) ↔ Cast(FP16)` islands, converts non-island weights to FP16, then bounds the RoPE island before QK^T (`bound_attention_core()`, `--no-bound-attn` to skip) so the attention core runs FP16 and TRT's FMHA fuser fires — 96/96 attentions on the medium DiT, 4.3× at L=4096. Writes both the modified `dit_fp16mixed.onnx` AND the TRT engine, which **must** be `STRONGLY_TYPED` (weakly-typed + `BuilderFlag.FP16` re-casts the FP32 islands and silently degrades to naive FP16). Only re-run when the model retrains or the island recipe changes. Requires `onnx` + `onnx-graphsurgeon`. | producer |
 | `build_t5gemma.py` | Trace + export T5Gemma encoder ONNX + build TRT | producer |
 | `build_same_s_decoder.py` | Trace + export SAME-S decoder ONNX + build TRT | producer |
 | `build_same_s_encoder.py` | Trace + export SAME-S encoder ONNX + build TRT | producer |

--- a/optimized/tensorRT/build/build.py
+++ b/optimized/tensorRT/build/build.py
@@ -67,15 +67,23 @@ TARGETS = [
      "outputs": ["same-l/dec_dynamic_triton_swa.trt"]},
     # DiT engines now build from pre-processed FP16-mixed ONNX on HF;
     # build_from_onnx.py does the simple STRONGLY_TYPED compile.
-    # Medium ships TWO engines: bf16 (FMHA-fused, the speed DEFAULT) built from
-    # the raw fp32 dit.onnx with BuilderFlag.BF16, and fp16-mixed (canonical,
-    # bit-reproducible, kept selectable). sm-music/sm-sfx are fp16-mixed only.
-    {"label": "DiT medium  (SA3-M, bf16 — FMHA-fused, medium DEFAULT)",
-     "command": _from_onnx("sa3-m-bf16"),
-     "outputs": ["sa3-m/dit_bf16.trt"]},
-    {"label": "DiT medium  (SA3-M, FP16-mixed — selectable, bit-reproducible)",
+    # Medium ships TWO engines: fp16-mixed (the DEFAULT since 2026-07 — its
+    # attention core now fuses, see below) and bf16 (built from the raw fp32
+    # dit.onnx with BuilderFlag.BF16). sm-music/sm-sfx are fp16-mixed only.
+    #
+    # fp16-mixed became the medium default when the RoPE island was bounded so
+    # QK^T + Softmax run FP16: the engine went 0 -> 96 fused MHA nodes and 4.3x
+    # faster at L=4096, which removed the speed reason to prefer bf16. It is also
+    # the accurate one — teacher-forced velocity cos 1.0000 vs the FP32 engine at
+    # every length, where bf16 evaluates RoPE's rotation angle too coarsely and
+    # drifts at long sequence (the angle reaches ~4155 rad at L=4092, where bf16's
+    # spacing is 32 rad — more than a full 2*pi rotation).
+    {"label": "DiT medium  (SA3-M, FP16-mixed — medium DEFAULT, attention-fused)",
      "command": _from_onnx("sa3-m"),
      "outputs": ["sa3-m/dit_fp16mixed.trt"]},
+    {"label": "DiT medium  (SA3-M, bf16 — selectable; drifts at long sequence)",
+     "command": _from_onnx("sa3-m-bf16"),
+     "outputs": ["sa3-m/dit_bf16.trt"]},
     {"label": "DiT sm-music (FP16-mixed)",
      "command": _from_onnx("sa3-sm-music"),
      "outputs": ["sa3-sm-music/dit_fp16mixed.trt"]},

--- a/optimized/tensorRT/build/build_dit_fp16mixed.py
+++ b/optimized/tensorRT/build/build_dit_fp16mixed.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
 """Build a SA3 DiT TRT engine in FP16-mixed precision: FP16 trunk with FP32
-islands around RMSNorm, attention Softmax, and (by default) the rotary
-position embedding regions that PyTorch marks @autocast(enabled=False).
+islands around RMSNorm and (by default) the rotary position embedding
+*generation* that PyTorch marks @autocast(enabled=False). The attention core
+(QK^T -> Softmax -> P.V) runs FP16 so TRT's FMHA fuser can fire — step 6 below.
 
 Background:
-- BF16 engine compounds quantization error over 8 sampling steps (cos drifts
-  from 0.99 single-step to ~0.81 final-latent vs PyTorch FP32).
+- The BF16 engine drifts at long sequence, and the cause is narrower than
+  "bf16 accumulates error over the 8 sampling steps": a per-op ablation showed
+  bf16 arithmetic everywhere else in the DiT is clean (GEMMs, RMSNorm, the
+  differential-attention subtraction, even the cos/sin tables). The single
+  culprit is the RoPE rotation ANGLE, t * inv_freq, which reaches ~4155 rad at
+  L=4092 — where bf16's spacing is 32 rad, five whole rotations — so cos/sin of
+  it is uncorrelated with the true value and position information for the
+  fast-rotating dims is destroyed. The axis that separates a good engine from a
+  bad one is therefore "fp32 angle island present", not fp16-vs-bf16.
 - Naive FP16 (just BuilderFlag.FP16) catastrophically diverges: TRT promotes
-  RMSNorm's Pow/ReduceMean/Sqrt and attention's Softmax to FP16, which
-  overflows (variance > 65504 and softmax denominator collapses).
+  RMSNorm's Pow/ReduceMean/Sqrt to FP16, which overflows (variance > 65504).
+  The Softmax is a different story — see bound_attention_core(): FP16 softmax
+  is fine, and an FP32 one costs 4.3x at L=4096 for nothing.
 - MLX gets away with FP16 because it casts those subgraphs to FP32 internally.
 
 This script reproduces that recipe on the ONNX side:
 
   1. Identify FP32 "islands":
        - Every RMSNorm chain (Pow -> ReduceMean -> Add -> Sqrt -> Div -> Mul -> Mul)
-       - Every Softmax
+       - Every Softmax (transient — step 6 hands the attention core back to FP16)
        - (mode=rope, default) Every region reachable from a Cast(to=FP32) that
          leads to Cos/Sin or Einsum — i.e. the rotary position embedding
          (@autocast(enabled=False) in PyTorch source)
@@ -29,8 +38,18 @@ This script reproduces that recipe on the ONNX side:
   5. Post-process: walk the graph inserting autocast nodes wherever two
      operands of a Mul/MatMul/Add/etc disagree on dtype (this handles the
      boundary between FP32 t5_hidden input and FP16 trunk).
-  6. Build a TRT engine with NetworkDefinitionCreationFlag.STRONGLY_TYPED
+  6. bound_attention_core(): terminate the RoPE island before QK^T so the
+     attention core (QK^T -> Softmax -> P.V) runs FP16 and TRT's FMHA fuser can
+     fire. Mirrors `apply_rotary_pos_emb`'s closing `t.to(out_dtype)`, which the
+     island passes above do not reproduce. WITHOUT this step the whole O(L^2)
+     attention core stays FP32: 0 fused MHA nodes and 4.3x slower at L=4096, for
+     no accuracy gain (teacher-forced cos vs FP32 is 1.0000 WITH the pass and
+     0.9998 without). See the function docstring. Disable with --no-bound-attn
+     only to reproduce the pre-2026-07 engines.
+  7. Build a TRT engine with NetworkDefinitionCreationFlag.STRONGLY_TYPED
      so TRT respects the per-tensor dtypes exactly (no auto-promotion).
+     STRONGLY_TYPED is mandatory, not stylistic: weakly-typed + BuilderFlag.FP16
+     lets TRT re-cast the FP32 RMSNorm islands and reintroduces the overflow.
 
 Inputs/outputs stay FP32 so the runtime can swap engines transparently.
 
@@ -463,20 +482,195 @@ def wrap_islands_with_casts(model, blocked_names):
     return model
 
 
-def fix_dtype_mismatches(model, blocked_names):
-    """Walk the graph and insert Cast nodes wherever two operands of the
-    same node disagree on dtype. We use a forward dtype propagation
-    starting from graph inputs and initializers, computing the dtype of
-    each tensor as it would appear at runtime. For binary/multi-input ops
-    (MatMul, Add, Mul, Div, Sub, Pow, Where, etc.) we ensure all operands
-    share the same dtype — if they differ, the lower-precision one is
-    upcast (we prefer upcasting to FP32 over downcasting to FP16 to avoid
-    silent precision loss). The exception: when the consuming node is in
-    `blocked_names`, all its inputs must be FP32 (no downcast); when the
-    consuming node is NOT blocked, we follow the majority of operand
-    dtypes.
+def bound_attention_core(model):
+    """Terminate the RoPE island before QK^T so the attention core runs FP16.
+
+    Why this pass exists
+    --------------------
+    find_fp32_islands() blocks every Softmax (section C) *and* the RoPE region.
+    Because RoPE emits q/k in FP32 and nothing casts them back,
+    fix_dtype_mismatches then keeps the QK^T MatMul in FP32 to match its operands.
+    Net effect: the entire O(L^2) attention core — QK^T, the scale Mul, and Softmax
+    — runs FP32, and TensorRT's FMHA fuser cannot fire on it. Measured on the
+    medium DiT: **0 fused MHA nodes and 4.3x slower at L=4096** than it needs to be.
+
+    Neither FP32 region is actually required:
+
+      * PyTorch does not keep the attention core in FP32. `apply_rotary_pos_emb`
+        ends with `t, t_unrotated = t.to(out_dtype), t_unrotated.to(out_dtype)` —
+        it computes in FP32 and casts *back* to the autocast dtype — and attention
+        is then `F.scaled_dot_product_attention(q, k, v)`, a fused kernel taking
+        FP16 inputs. The FP32 softmax island has no counterpart in the source.
+      * TRT's FMHA kernels accumulate softmax in FP32 internally, so the explicit
+        FP32 softmax buys nothing the kernel does not already do.
+
+    So for each attention this rewrites
+
+        Mul(fp32) -> MatMul(fp32,fp32) -> Cast(fp32)[no-op] -> Softmax(fp32) -> Cast(fp16) -> MatMul(P.V)
+    to
+        Mul(fp32) -> Cast(fp16) x2 -> MatMul(fp16) ->            Softmax(fp16) ->            MatMul(P.V)
+
+    mirroring the source's cast-back. The RMSNorm islands are untouched: those
+    guard variance *overflow* (FP16's 5-bit exponent), a different failure mode
+    from precision, and they are still required.
+
+    Verified on sa3-m: 96/96 attentions converted, 96 fused MHA nodes at FP16,
+    teacher-forced velocity cos 1.0000 vs the FP32 engine at L=256/1292/4092
+    (the unbounded graph matches it at 256/1292 but drops to 0.9998 at 4092), and
+    4.3x faster at L=4096.
+
+    Scope: only the medium DiT has the unbounded island. In sa3-sm-music /
+    sa3-sm-sfx the RoPE island already terminates before QK^T (verified: their
+    QK^T operands are FP16, so their published engines fuse 40/40 MHA), and what
+    the pass converts there is the Softmax island alone — a real change to those
+    graphs, but not the fix this exists for. Their published ONNX/engines predate
+    the pass; --no-bound-attn skips it and reproduces the graph they were built
+    from.
+
+    NOTE the resulting graph must be built STRONGLY_TYPED. Building it weakly-typed
+    with BuilderFlag.FP16 lets TRT re-cast the FP32 RMSNorm islands too, which is
+    the naive-FP16 overflow this recipe exists to prevent (measured: teacher-forced
+    cos collapses to 0.88).
+    """
+    from collections import defaultdict
+    from onnx import TensorProto, helper
+
+    g = model.graph
+    producer = {}
+    consumers = defaultdict(list)
+    for n in g.node:
+        for o in n.output:
+            producer[o] = n
+        for i in n.input:
+            if i:
+                consumers[i].append(n)
+    graph_outputs = {o.name for o in g.output}
+
+    def cast_to(node):
+        for a in node.attribute:
+            if a.name == "to":
+                return a.i
+        return None
+
+    drop, rename, new_casts = set(), {}, []
+    converted, converted_softmax = 0, []
+    skipped = defaultdict(int)
+
+    for sm in [n for n in g.node if n.op_type == "Softmax"]:
+        pre = producer.get(sm.input[0])
+        if pre is None or pre.op_type != "Cast" or cast_to(pre) != TensorProto.FLOAT:
+            skipped["no_fp32_cast_before_softmax"] += 1
+            continue
+        if len(consumers[sm.input[0]]) != 1:
+            skipped["pre_cast_output_shared"] += 1
+            continue
+        qk = producer.get(pre.input[0])
+        if qk is None or qk.op_type != "MatMul":
+            skipped["upstream_not_matmul"] += 1
+            continue
+        posts = consumers[sm.output[0]]
+        if not posts or any(p.op_type != "Cast" or cast_to(p) != TensorProto.FLOAT16
+                            for p in posts):
+            skipped["no_fp16_cast_after_softmax"] += 1
+            continue
+        if sm.output[0] in graph_outputs or any(p.output[0] in graph_outputs for p in posts):
+            skipped["touches_graph_output"] += 1
+            continue
+        if len(consumers[qk.output[0]]) != 1:
+            skipped["qk_output_shared"] += 1
+            continue
+
+        for idx, src in enumerate(list(qk.input)):
+            out_name = f"{src}__attnfp16_{converted}_{idx}"
+            new_casts.append(helper.make_node(
+                "Cast", [src], [out_name], to=TensorProto.FLOAT16,
+                name=f"{src}__attnfp16_cast_{converted}_{idx}"))
+            qk.input[idx] = out_name
+        sm.input[0] = qk.output[0]
+        drop.add(id(pre))
+        for p in posts:
+            rename[p.output[0]] = sm.output[0]
+            drop.add(id(p))
+        converted += 1
+        converted_softmax.append(sm)
+
+    print(f"  bound_attention_core: {converted} attention(s) -> FP16 core")
+    if skipped:
+        print(f"    skipped: {dict(skipped)}")
+    if converted == 0:
+        raise RuntimeError("bound_attention_core converted nothing — the island "
+                           "passes upstream must have changed shape")
+
+    def resolve(name):
+        seen = set()
+        while name in rename and name not in seen:
+            seen.add(name)
+            name = rename[name]
+        return name
+
+    kept = [n for n in g.node if id(n) not in drop]
+    for n in kept:
+        for i, t in enumerate(n.input):
+            r = resolve(t)
+            if r != t:
+                n.input[i] = r
+
+    # Each new Cast must precede its consumer to keep the graph topologically sorted.
+    cast_by_output = {c.output[0]: c for c in new_casts}
+    ordered = []
+    for n in kept:
+        for t in n.input:
+            c = cast_by_output.pop(t, None)
+            if c is not None:
+                ordered.append(c)
+        ordered.append(n)
+    if cast_by_output:
+        raise RuntimeError(f"{len(cast_by_output)} inserted casts could not be placed")
+    del g.node[:]
+    g.node.extend(ordered)
+
+    # Retype/drop stale value_info: QK^T and Softmax outputs are FP16 now, and the
+    # spliced Cast outputs no longer exist. A stale FP32 declaration on an FP16
+    # tensor makes STRONGLY_TYPED reject the graph. Only the attentions we actually
+    # converted move — a skipped Softmax keeps its FP32 declaration.
+    retype = set()
+    for sm in converted_softmax:
+        retype.add(sm.output[0])
+        retype.add(sm.input[0])     # rewired above to the QK^T MatMul output
+    dead = set(rename)
+    kept_vi = []
+    for vi in g.value_info:
+        if vi.name in dead:
+            continue
+        if vi.name in retype and vi.type.tensor_type.elem_type == TensorProto.FLOAT:
+            vi.type.tensor_type.elem_type = TensorProto.FLOAT16
+        kept_vi.append(vi)
+    del g.value_info[:]
+    g.value_info.extend(kept_vi)
+    return model
+
+
+def fix_dtype_mismatches(model, blocked_names, low_dt=None):
+    """Insert Cast nodes wherever two operands of an op disagree on float dtype.
+
+    Forward dtype propagation from graph inputs and initializers, computing each
+    tensor's dtype as it would appear at runtime. For binary/multi-input ops
+    (MatMul, Add, Mul, Div, Sub, Pow, Where, ...) all float operands are aligned
+    onto one dtype: FP32 when the consuming node is in `blocked_names` (an FP32
+    island — never downcast those), otherwise the trunk dtype, and the mismatched
+    operands get a Cast.
+
+    `low_dt` is that trunk dtype: FLOAT16 for the fp16-mixed recipe (the default
+    when None) or BFLOAT16 for a bf16 trunk. Both recipes need the same graph-wide
+    reconciliation — a bf16 trunk with fp32 islands hits exactly the same class of
+    mismatch (`ElementWiseOperation DIV must have same input types`,
+    `IMatrixMultiplyLayer must have same input types`) — so this pass is shared
+    rather than duplicated.
     """
     from onnx import TensorProto, helper
+
+    if low_dt is None:
+        low_dt = TensorProto.FLOAT16    # default trunk dtype: the fp16-mixed recipe
 
     init_dtype = {init.name: init.data_type for init in model.graph.initializer}
     graph_input_dtype = {gi.name: gi.type.tensor_type.elem_type for gi in model.graph.input}
@@ -566,17 +760,17 @@ def fix_dtype_mismatches(model, blocked_names):
             if not inp:
                 continue
             dt = get_dt(inp)
-            if dt in (TensorProto.FLOAT, TensorProto.FLOAT16):
+            if dt in (TensorProto.FLOAT, low_dt):
                 float_input_dts.append((inp, dt))
         if node.op_type in SHARED_FLOAT_DT_OPS and len(float_input_dts) > 1:
             unique_dts = set(dt for _, dt in float_input_dts)
             if len(unique_dts) > 1:
                 # Mismatch — need to align. Rule: if blocked node, force FP32.
-                # Otherwise prefer FP16 (the trunk dtype).
+                # Otherwise prefer low_dt (the trunk dtype, FP16 by default).
                 if node.name in blocked_names:
                     target = TensorProto.FLOAT
                 else:
-                    target = TensorProto.FLOAT16
+                    target = low_dt
                 for inp, dt in float_input_dts:
                     if dt == target:
                         continue
@@ -601,7 +795,7 @@ def fix_dtype_mismatches(model, blocked_names):
                 if not inp:
                     continue
                 dt = get_dt(inp)
-                if dt in (TensorProto.FLOAT, TensorProto.FLOAT16):
+                if dt in (TensorProto.FLOAT, low_dt):
                     for o in node.output:
                         set_dt(o, dt)
                     break
@@ -807,7 +1001,7 @@ def manual_convert_to_fp16(model, blocked_names):
     return model
 
 
-def convert_to_fp16mixed(input_onnx, output_onnx, mode="minimal"):
+def convert_to_fp16mixed(input_onnx, output_onnx, mode="minimal", bound_attn=True):
     """Load FP32 ONNX, identify FP32 islands, convert everything else to
     FP16, and save."""
     import onnx
@@ -863,6 +1057,11 @@ def convert_to_fp16mixed(input_onnx, output_onnx, mode="minimal"):
     # FP16 tensor, or where Cast(to=FP32) outputs reach FP16 consumers, etc.
     print(f"  fixing dtype mismatches with autocast insertion...")
     fp16_model = fix_dtype_mismatches(fp16_model, blocked_names)
+
+    # The island passes above leave the whole O(L^2) attention core in FP32 —
+    # see bound_attention_core() for why that is wrong and what it costs.
+    if bound_attn:
+        fp16_model = bound_attention_core(fp16_model)
 
     print(f"  saving to {output_onnx}")
     # Try a plain save first; if the protobuf exceeds 2GB, fall back to
@@ -955,6 +1154,12 @@ def main():
                     help="FP32 island coverage: minimal=RMSNorm+Softmax only, "
                          "rope=+RoPE freq/apply_rotary, full=every Cast(FP32) "
                          "downstream region from the original ONNX.")
+    ap.add_argument("--no-bound-attn", action="store_true",
+                    help="Skip bound_attention_core(). NOT recommended: leaving the "
+                         "RoPE island unbounded keeps QK^T + Softmax in FP32, which "
+                         "blocks TRT's FMHA fuser (0 fused MHA nodes, 4.3x slower at "
+                         "L=4096) for no accuracy gain. Only for reproducing the "
+                         "pre-2026-07 engines.")
     ap.add_argument("--skip-convert", action="store_true",
                     help="Skip ONNX conversion (reuse existing --onnx file)")
     ap.add_argument("--skip-build", action="store_true",
@@ -963,7 +1168,8 @@ def main():
 
     if not args.skip_convert:
         print(f"━━━ Convert FP32 ONNX -> FP16-mixed ONNX (mode={args.mode}) ━━━")
-        convert_to_fp16mixed(args.input, args.onnx, mode=args.mode)
+        convert_to_fp16mixed(args.input, args.onnx, mode=args.mode,
+                             bound_attn=not args.no_bound_attn)
 
     if not args.skip_build:
         print("\n━━━ Build TRT engine ━━━")

--- a/optimized/tensorRT/build/build_dit_profile.py
+++ b/optimized/tensorRT/build/build_dit_profile.py
@@ -22,9 +22,11 @@ Args:
 Optional flags:
     --opt N           Optimization point on L axis (default 1292). TRT picks
                        kernels to run fastest at this shape.
-    --precision P     "bf16" (default, matches canonical build) or "fp32"
-                       (omits the BF16 flag entirely — forces full FP32
-                       execution; engine ~2x larger, build slower).
+    --precision P     "bf16" (default; matches the sa3-m-bf16 recipe, NOT the
+                       canonical fp16-mixed one — this script builds from the raw
+                       fp32 dit.onnx) or "fp32" (omits the BF16 flag entirely —
+                       forces full FP32 execution; engine ~2x larger, build
+                       slower).
 
 Build flags mirror sa3-sm-music / sa3-m in build_from_onnx.py: BF16 +
 EXPLICIT_BATCH, 16 GB workspace. With --precision fp32 the BF16 flag is
@@ -188,7 +190,8 @@ def main():
                     help="Maximum L for the profile (default 4096). Set to "
                          "match min for a fully-static engine.")
     ap.add_argument("--precision", choices=("bf16", "fp32"), default="bf16",
-                    help="Builder precision: bf16 (default, matches canonical) "
+                    help="Builder precision: bf16 (default; matches the "
+                         "sa3-m-bf16 recipe, not the canonical fp16-mixed one) "
                          "or fp32 (omits BF16 flag, forces FP32 throughout).")
     args = ap.parse_args()
     build_dit(args.target_name, args.profile_min, args.output_name,

--- a/optimized/tensorRT/build/build_from_onnx.py
+++ b/optimized/tensorRT/build/build_from_onnx.py
@@ -141,18 +141,26 @@ TARGETS = {
         "profile":      _DIT_PROFILE,
         "plugin":       False,
     },
-    # SA3 medium DiT in bf16 — the medium SPEED DEFAULT (fp16-mixed above stays
-    # selectable). Reuses the SAME raw fp32 dit.onnx as the fp32 variant, but
-    # builds with BuilderFlag.BF16 + EXPLICIT_BATCH (NOT STRONGLY_TYPED): bf16
-    # carries fp32's dynamic range, so the FP32-softmax islands that fp16-mixed
-    # kept vanish and TRT 10.15's FMHA fuser fires (0 → 96 fused _gemm_mha_v2
-    # nodes) → measured ~1.76×@L=256 / 4.70×@L=4096 vs fp16-mixed, within the
-    # perceptual re-seed floor (FAD 0.59× floor, CLAP within spread, n=128).
-    # It is a build-time PRECISION RECIPE only — no new ONNX, no graph change.
+    # SA3 medium DiT in bf16 — SELECTABLE, no longer the medium default (see the
+    # sa3-m entry above). Reuses the SAME raw fp32 dit.onnx as the fp32 variant,
+    # but builds with BuilderFlag.BF16 + EXPLICIT_BATCH (NOT STRONGLY_TYPED): a
+    # uniform bf16 trunk lets TRT 10.15's FMHA fuser fire (0 → 96 fused
+    # _gemm_mha_v2 nodes). It is a build-time PRECISION RECIPE only — no new
+    # ONNX, no graph change.
+    #
+    # The ~1.76×@L=256 / 4.70×@L=4096 speedup this engine was shipped for was
+    # measured against an fp16-mixed engine whose attention core was stuck in
+    # FP32; with that fixed (build_dit_fp16mixed.py's bound_attention_core) bf16
+    # is only ~3% ahead, and it loses on accuracy: weakly-typed BF16 also lets
+    # TRT evaluate RoPE's rotation angle in bf16, and that angle reaches ~4155
+    # rad at L=4092 where bf16's spacing is 32 rad (> 2π), so position info for
+    # the fast-rotating dims is destroyed — the latent inflates ~2.5× over 8
+    # steps and a 6-min render clips 2–3% of samples. Clean at short lengths.
+    # (The FAD 0.59× floor / CLAP-within-spread n=128 result that cleared this
+    # engine predates the long-sequence finding.)
     # medium-only: sm-music / sm-sfx use standard attention and already fuse in
-    # their fp16-mixed engines. bf16 is NOT seed-reproducible vs fp16-mixed
-    # (differential attention is cancellation-sensitive) — a different-but-equal
-    # take per seed; use fp16-mixed for bit-reproducibility.
+    # their fp16-mixed engines. bf16 is also NOT seed-reproducible vs fp16-mixed;
+    # use fp16-mixed for bit-reproducibility.
     # Same _DIT_PROFILE (batch=1, dynamic L∈[1,4096], opt=1292) as every DiT
     # engine → identical CLI/feature surface (varlen, CFG sequential dual-pass,
     # neg-prompt/APG, a2a, inpaint). The DiT ONNX bakes batch=1, so there is no

--- a/optimized/tensorRT/scripts/sa3_trt.py
+++ b/optimized/tensorRT/scripts/sa3_trt.py
@@ -404,13 +404,14 @@ class SA3Inference:
         Args:
             dit:            one of DIT_CHOICES — "sm-music" / "sm-sfx" / "medium"
             decoder:        one of DECODER_PATHS — "same-s" / "same-l"
-            precision:      None (default → per model: "bf16" for medium, else
-                            "fp16mixed"), or an explicit "bf16" (medium only;
-                            FMHA-fused, ~1.8-4.7× faster, within the perceptual
-                            floor, not seed-reproducible vs fp16mixed),
-                            "fp16mixed" (canonical, bit-reproducible), or "fp32"
-                            (bit-equiv PyTorch eager, ~2× slower). Engines auto-
-                            download from HF if the requested file is missing.
+            precision:      None (default → "fp16mixed" for every model), or an
+                            explicit "fp16mixed" (canonical: FP16 trunk, FP32
+                            RMSNorm/RoPE islands, FMHA-fused FP16 attention core),
+                            "bf16" (medium only; ~3% faster but its bf16 RoPE
+                            angle drifts at long sequence, and not seed-
+                            reproducible vs fp16mixed), or "fp32" (bit-equiv
+                            PyTorch eager, ~2× slower). Engines auto-download
+                            from HF if the requested file is missing.
             default_T_lat:  latent length to build the initial graph at
             default_steps:  pingpong steps for the initial graph
             default_seconds: duration condition for the initial graph (used for
@@ -424,8 +425,8 @@ class SA3Inference:
             raise ValueError(f"unknown dit={dit!r}; valid: {list(DIT_CHOICES)}")
         if decoder not in DECODER_PATHS:
             raise ValueError(f"unknown decoder={decoder!r}; valid: {list(DECODER_PATHS)}")
-        # Resolve precision default per model: bf16 for medium (FMHA-fused speed
-        # default), fp16-mixed for sm-music/sm-sfx. bf16 is medium-only.
+        # Resolve precision default per model: fp16-mixed everywhere.
+        # bf16 is medium-only and selectable.
         if precision is None:
             precision = canon.default_precision(dit)
         if precision not in canon.PRECISIONS:
@@ -645,11 +646,13 @@ def main():
     ap.add_argument("--dit", choices=list(DIT_CHOICES.keys()), default=None)
     ap.add_argument("--decoder", choices=list(DECODER_PATHS.keys()), default=None)
     ap.add_argument("--precision", choices=list(canon.PRECISIONS), default=None,
-                    help="DiT engine precision. Default resolves per model: 'bf16' for medium "
-                         "(FMHA-fused, ~1.8-4.7× faster, within perceptual floor; not "
-                         "seed-reproducible vs fp16mixed), 'fp16mixed' for sm-music/sm-sfx. "
-                         "'fp16mixed' = canonical/bit-reproducible. 'fp32' = bit-equiv PyTorch "
-                         "eager, slower. bf16 is medium-only. Auto-downloads from HF.")
+                    help="DiT engine precision. Default is 'fp16mixed' for every model: "
+                         "canonical FP16 trunk + FP32 RMSNorm/RoPE islands + FMHA-fused FP16 "
+                         "attention core, fp32-accurate at every length. 'bf16' (medium only) "
+                         "is ~3%% faster but evaluates RoPE's angle in bf16 and drifts at long "
+                         "sequence (clips on a 6-min render); not seed-reproducible vs "
+                         "fp16mixed. 'fp32' = bit-equiv PyTorch eager, slower. "
+                         "Auto-downloads from HF.")
     ap.add_argument("--models-dir", default=str(canon.MODELS_DIR))
     ap.add_argument("--seconds", type=float, default=30.0)
     ap.add_argument("--steps", type=int, default=8)

--- a/optimized/tensorRT/scripts/sa3_trt_core.py
+++ b/optimized/tensorRT/scripts/sa3_trt_core.py
@@ -617,9 +617,22 @@ class DiTRunner:
         ctx.set_tensor_address("seconds_total",  self._sec_buf.data_ptr())
         ctx.set_tensor_address("local_add_cond", local_add_cond.float().contiguous().data_ptr())
         ctx.set_tensor_address("velocity",       self._vel_buf.data_ptr())
-        ctx.execute_async_v3(self.runner.stream.cuda_stream)
+        if not ctx.execute_async_v3(self.runner.stream.cuda_stream):
+            raise RuntimeError(
+                f"DiT execute_async_v3 failed (L={L}). A failed enqueue otherwise "
+                f"returns the previous buffer contents as if it had succeeded.")
         self.runner.stream.synchronize()
-        return self._vel_buf.float()
+        # .clone(), NOT .float(): _vel_buf is already FP32, so .float() is a no-op
+        # that hands back the SAME tensor every call. Any caller holding two
+        # results at once then sees one aliased buffer — which silently turned CFG
+        # into a no-op, because
+        #     v_cond   = dit.step(..., embeds,      ...)
+        #     v_uncond = dit.step(..., null_embeds, ...)
+        # left v_cond pointing at the unconditional velocity, so the guided render
+        # followed the NEGATIVE prompt. Returning a copy is the contract callers
+        # already assume. (The graph-capture path is unaffected: it reads
+        # _out_buf under an explicit capture protocol.)
+        return self._vel_buf.clone()
 
     def bind_persistent(self, L: int):
         """Allocate persistent input buffers + bind tensor addresses once.

--- a/optimized/tensorRT/scripts/sa3_trt_core.py
+++ b/optimized/tensorRT/scripts/sa3_trt_core.py
@@ -103,7 +103,7 @@ T5GEMMA_PATH = ARCH_DIR / "t5gemma" / "t5gemma_fp16mixed.trt"
 DIT_ENGINE_FILES = {
     "sm-music": ["sa3-sm-music/dit_fp16mixed.trt"],
     "sm-sfx":   ["sa3-sm-sfx/dit_fp16mixed.trt"],
-    "medium":   ["sa3-m/dit_bf16.trt"],   # bf16 (FMHA-fused) is the medium default
+    "medium":   ["sa3-m/dit_fp16mixed.trt"],   # fp16mixed is the medium default
 }
 DECODER_FILES = {
     "same-s": [
@@ -129,7 +129,7 @@ DIT_CHOICES = {
                  "default_decoder": "same-s"},
     "sm-sfx":   {"engine": ARCH_DIR / "sa3-sm-sfx" / "dit_fp16mixed.trt",
                  "default_decoder": "same-s"},
-    "medium":   {"engine": ARCH_DIR / "sa3-m" / "dit_bf16.trt",   # bf16 = medium default
+    "medium":   {"engine": ARCH_DIR / "sa3-m" / "dit_fp16mixed.trt",  # medium default
                  "default_decoder": "same-l"},
 }
 DECODER_PATHS = {
@@ -145,18 +145,24 @@ ENCODER_PATHS = {
 # ─── Precision-keyed engine maps ─────────────────────────────────────────
 #
 # Three DiT precisions:
+#   fp16mixed  — canonical AND the default for every DiT, medium included since
+#                2026-07. FP16 trunk with FP32 islands around RMSNorm and the RoPE
+#                *generation*; the attention core (QK^T → Softmax → P·V) runs FP16
+#                so TRT's FMHA fuser fires (96 fused nodes on medium). Before that
+#                island was bounded the whole O(L²) core sat in FP32 unfused, which
+#                is what made bf16 look 4.7× faster. Now: teacher-forced velocity
+#                cos 1.0000 vs the FP32 engine at every length, and within ~3% of
+#                bf16's speed. Requires STRONGLY_TYPED (see build_dit_fp16mixed.py).
 #   bf16       — medium ONLY. Same dit.onnx as fp32, built with BuilderFlag.BF16
-#                (EXPLICIT_BATCH). bf16 carries fp32's range, so the FP32-softmax
-#                islands vanish and TRT 10.15's FMHA fuser fires (0 → 96 fused
-#                _gemm_mha_v2 nodes) → 1.76×@256 / 4.70×@4096 vs fp16-mixed,
-#                within the perceptual re-seed floor (FAD 0.59× floor, n=128).
-#                NOT seed-reproducible vs fp16-mixed (differential attention is
-#                cancellation-sensitive → a different-but-equal take per seed).
-#                THE MEDIUM DEFAULT. (sm-music/sm-sfx use standard attention and
-#                already fuse in fp16-mixed — no bf16 engine for them.)
-#   fp16mixed  — canonical (FP16 trunk + FP32 islands around RMSNorm/Softmax/
-#                RoPE). Kept selectable for bit-reproducibility / max per-step
-#                fidelity. The sm-music / sm-sfx default.
+#                (EXPLICIT_BATCH), which lets the FMHA fuser fire on a uniform bf16
+#                trunk. Marginally the fastest engine, but LOW-FIDELITY AT LONG
+#                SEQUENCE: it evaluates RoPE's rotation angle in bf16, and that
+#                angle reaches ~4155 rad at L=4092 where bf16's spacing is 32 rad
+#                (> 2π), so position information for the fast-rotating dims is
+#                destroyed. Over 8 sampling steps the latent inflates ~2.5× and the
+#                decoder clips 2–3% of samples on a 6-min render. Fine at short
+#                lengths (clean at L=256); prefer fp16mixed for anything long.
+#                Also not seed-reproducible vs fp16mixed.
 #   fp32       — pure-FP32, bit-equivalent to PyTorch eager. ~2× size/latency.
 #
 # The lookup tables below resolve the engine filename per (dit/decoder,
@@ -165,7 +171,7 @@ ENCODER_PATHS = {
 # by bf16 (it's a DiT-trunk fusion recipe), so decoder "bf16" reuses the
 # canonical decoder engine. Encoders are FP16-mixed only.
 DIT_ENGINE_FILENAME = {
-    "bf16":      "dit_bf16.trt",        # medium only (FMHA-fused; medium default)
+    "bf16":      "dit_bf16.trt",        # medium only; drifts at long sequence
     "fp16mixed": "dit_fp16mixed.trt",
     "fp32":      "dit_fp32.trt",
 }
@@ -175,8 +181,11 @@ _DIT_PRECISIONS = {
     "sm-sfx":   ("fp16mixed", "fp32"),
     "medium":   ("bf16", "fp16mixed", "fp32"),
 }
-# Per-DiT default precision (bf16 for medium, fp16mixed elsewhere).
-DIT_DEFAULT_PRECISION = {"sm-music": "fp16mixed", "sm-sfx": "fp16mixed", "medium": "bf16"}
+# Per-DiT default precision — fp16mixed everywhere. Medium moved off bf16 once
+# fp16mixed's attention core was fused (4.3x faster than the old fp16mixed engine,
+# ~3% off bf16, and fp32-accurate at every sequence length).
+DIT_DEFAULT_PRECISION = {"sm-music": "fp16mixed", "sm-sfx": "fp16mixed",
+                         "medium": "fp16mixed"}
 _DIT_SUBDIR = {"sm-music": "sa3-sm-music", "sm-sfx": "sa3-sm-sfx", "medium": "sa3-m"}
 DECODER_ENGINE_FILENAME = {
     "same-l": {
@@ -195,8 +204,13 @@ PRECISIONS = ("bf16", "fp16mixed", "fp32")
 
 
 def default_precision(dit_name: str) -> str:
-    """Default DiT precision for a model: bf16 for medium (FMHA-fused speed
-    default), fp16-mixed otherwise."""
+    """Default DiT precision: fp16-mixed for every model.
+
+    Medium used bf16 until 2026-07, when bounding the fp16-mixed RoPE island let
+    its attention core fuse — that made fp16-mixed 4.3x faster than before and
+    within ~3% of bf16, while staying accurate at long sequence (bf16 evaluates
+    RoPE's angle too coarsely past ~2048 rad and drifts).
+    """
     return DIT_DEFAULT_PRECISION.get(dit_name, "fp16mixed")
 
 
@@ -229,7 +243,7 @@ def get_engine_files(dit_name: str, decoder_name: str, precision: str = None,
                        with_encoder: bool = False) -> list[str]:
     """Relative paths (under ARCH_DIR) needed for the chosen pipeline. Pass this
     list to _ensure_files() to auto-download anything missing from HF.
-    precision=None resolves to the per-model default (bf16 for medium)."""
+    precision=None resolves to the per-model default (fp16-mixed)."""
     if precision is None:
         precision = default_precision(dit_name)
     files = list(SHARED_FILES)
@@ -954,9 +968,9 @@ def prompt_user_if_missing(args):
         suggested = DIT_CHOICES[args.dit]["default_decoder"]
         args.decoder = _arrow_pick("Choose audio decoder:", list(DECODER_PATHS.keys()), default=suggested)
         print(f"  → {args.decoder}")
-    # Resolve DiT precision default per model: bf16 for medium (FMHA-fused speed
-    # default), fp16-mixed for sm-music/sm-sfx. bf16 is medium-only (sm-music/
-    # sm-sfx use standard attention and already fuse in fp16mixed).
+    # Resolve DiT precision default per model: fp16-mixed everywhere. bf16 is
+    # medium-only and selectable (sm-music / sm-sfx use standard attention and
+    # already fuse in fp16mixed).
     if getattr(args, "precision", None) is None:
         args.precision = default_precision(args.dit)
     if args.precision == "bf16" and args.dit != "medium":
@@ -1010,13 +1024,14 @@ def main():
                     help="Audio decoder. 'same-s' pairs with sm-* (110 MB engine). "
                          "'same-l' pairs with medium (1.2 GB engine). Interactive picker if omitted.")
     ap.add_argument("--precision", choices=list(PRECISIONS), default=None,
-                    help="DiT engine precision (default resolves per model: 'bf16' for medium, "
-                         "'fp16mixed' for sm-music/sm-sfx). 'bf16' (MEDIUM ONLY) = FMHA-fused, "
-                         "~1.8-4.7× faster than fp16mixed, within the perceptual floor, but not "
-                         "seed-reproducible vs fp16mixed (differential attention). 'fp16mixed' = "
-                         "FP16 trunk + FP32 islands (canonical, bit-reproducible). 'fp32' = pure "
-                         "FP32, matches PyTorch eager bit-for-bit but ~2× slower and ~2× the VRAM. "
-                         "Engines auto-download from HF if missing.")
+                    help="DiT engine precision (default is 'fp16mixed' for every model). "
+                         "'fp16mixed' = FP16 trunk + FP32 RMSNorm/RoPE islands with an FMHA-fused "
+                         "FP16 attention core (canonical; fp32-accurate at every length). "
+                         "'bf16' (MEDIUM ONLY) = ~3%% faster still, but it evaluates RoPE's angle "
+                         "in bf16 and drifts at long sequence (clips 2-3%% of samples on a 6-min "
+                         "render); fine for short clips, not seed-reproducible vs fp16mixed. "
+                         "'fp32' = pure FP32, matches PyTorch eager bit-for-bit but ~2× slower "
+                         "and ~2× the VRAM. Engines auto-download from HF if missing.")
     ap.add_argument("--models-dir", default=str(MODELS_DIR),
                     help=f"Directory containing the TRT engines. Default: {MODELS_DIR}")
     # ── Sampling ──


### PR DESCRIPTION
Code companion to the two HuggingFace PRs on `stabilityai/stable-audio-3-optimized`:
[#3](https://huggingface.co/stabilityai/stable-audio-3-optimized/discussions/3) (merged — corrected `onnx/sa3-m/dit_fp16mixed.onnx`) and
[#4](https://huggingface.co/stabilityai/stable-audio-3-optimized/discussions/4) (open — rebuilt `sm_90` + new `sm_120` engines).
This PR carries the producer pass that generates that ONNX, the runtime default change, and the docs.

## The bug

`build_dit_fp16mixed.py`'s island passes kept the medium DiT's entire O(L²) attention core in FP32:

- `find_fp32_islands()` blocks **every** `Softmax` (section C), and
- the RoPE island emits q/k in FP32 with nothing casting them back, so `fix_dtype_mismatches()` then kept the QK^T `MatMul` FP32 to match its operands.

Result: **0 fused MHA nodes** and **4.3× slower at L=4096** than necessary — for no accuracy gain.

Neither FP32 region was ever required:

- PyTorch does not keep the attention core in FP32. `apply_rotary_pos_emb` ends with `t.to(out_dtype)` — it computes in FP32 and casts *back* to the autocast dtype — and attention is then `F.scaled_dot_product_attention(q, k, v)`, a fused kernel taking FP16 inputs. The FP32 softmax island has no counterpart in the source.
- TRT's FMHA kernels accumulate softmax in FP32 internally, so an explicit FP32 softmax buys nothing the kernel does not already do.

## The fix

A new `bound_attention_core()` pass terminates the RoPE island before QK^T, mirroring the source's cast-back:

```
before: Mul(fp32) → MatMul(fp32,fp32) → Cast(fp32)[no-op] → Softmax(fp32) → Cast(fp16) → MatMul(P·V)
after:  Mul(fp32) → Cast(fp16)×2 → MatMul(fp16) →           Softmax(fp16) →             MatMul(P·V)
```

96/96 attentions convert on `sa3-m`. The RMSNorm islands are untouched — those guard variance *overflow* (FP16's 5-bit exponent), a different failure mode from precision, and are still required.

## Measured

Per DiT forward, CUDA-event median of 7 after 3 warmup, TF32 off, batch 1, dedicated idle GPU, TRT 10.15.1.29.

**NVIDIA RTX PRO 4500 Blackwell Server Edition** (sm_120 · 82 SM · 32 GB GDDR7 · 165 W):

| L | published | this PR | speedup |
|---|---|---|---|
| 256 | 23.4 ms | **17.6 ms** | 1.33× |
| 1292 | 99.2 ms | **44.4 ms** | 2.24× |
| 4096 | 714.0 ms | **166.1 ms** | **4.3×** |

**NVIDIA H200** (sm_90 · 132 SM · 141 GB HBM3e · 700 W):

| L | published | this PR | speedup |
|---|---|---|---|
| 256 | 11.1 ms | **7.4 ms** | 1.49× |
| 1292 | 27.9 ms | **12.2 ms** | 2.28× |
| 4096 | 180.9 ms | **41.4 ms** | **4.4×** |

> The absolute milliseconds belong to those two specific cards and are not comparable to each other — a 700 W datacenter part and a mid-range 165 W workstation part. Other sm_120 cards (RTX 5090, RTX PRO 6000 Blackwell) carry roughly twice the SM count and will be faster in absolute terms. The **ratio** is the portable result, and it held within 0.1× across two very different architectures, which is what you expect from a change about kernel fusion rather than silicon.

Accuracy against the `dit_fp32.trt` reference **built and run on the same card** (seed 6000, 8-step pingpong, TF32 off) — free-run latent std ratio · teacher-forced velocity cosine:

| medium DiT @L=4096 | published | this PR |
|---|---|---|
| fused MHA nodes | 0 | **96** |
| teacher-forced velocity cos vs FP32 | 0.9998 | **1.0000** |
| free-run latent std vs FP32 | 1.00× | 1.00× |
| 380 s render: clipped / crest | 0.000% / 6.62 | 0.001% / 6.51 |

Faster **and** marginally more accurate — closer to eager semantics than the graph it replaces, since PyTorch also runs the attention core at the autocast dtype inside fused SDPA.

## Runtime default: medium moves from `bf16` to `fp16mixed`

`dit_bf16.trt` was the medium default because the fp16-mixed engine was 4.7× slower at L=4096. With the core fused that gap is gone — fp16-mixed is now within ~3% of bf16 — and fp16-mixed is the accurate one:

| engine | L=256 std/cos | L=1292 std/cos | L=4092 std/cos |
|---|---|---|---|
| **fp16mixed (this PR)** | 1.00× / **1.0000** | 1.00× / **1.0000** | 1.00× / **1.0000** |
| bf16 (shipped) | 1.01× / 0.9958 | 1.31× / 0.7611 | **2.50× / 0.5477** ⚠ |

`bf16` stays selectable via `--precision bf16` (medium only), but is now documented as long-sequence-unsafe rather than "within the perceptual floor". Cause, from a per-op ablation: it evaluates RoPE's rotation angle in bf16. That angle is `t · inv_freq` with `inv_freq[0] == 1.0`, so it reaches ~4155 rad at L=4092, where bf16's spacing is 32 rad — more than a full 2π rotation, five times over — and `cos`/`sin` of it carry no position information for the fast-rotating dims (9 of 16 frequency pairs destroyed). The latent inflates ~2.5× over the 8 steps and a 6-minute render clips 2–3% of samples. It is clean at short lengths.

The earlier explanation for that defect — catastrophic cancellation in the differential-attention subtraction — was never ablated and is wrong: doing that subtraction in bf16 gives latent std 0.9172 against fp32's 0.9162. Comments and docs that repeated it are corrected here, along with the "naive FP16 overflows the attention softmax" claim (FP16 softmax measures at cos 1.0000; only the RMSNorm islands are load-bearing).

## Compatibility

- Engine filename, ONNX filename, and the `fp16mixed` precision name are all unchanged. No consumer config changes; the medium default simply resolves to `sa3-m/dit_fp16mixed.trt` instead of `sa3-m/dit_bf16.trt`.
- **Output changes at a fixed seed.** This is a bug fix, not a re-tune: renders differ from the previous engine, and medium's default engine changes. Deterministic and reproducible going forward, but not bit-identical to the old one.
- Rebuild affected engines with `build_from_onnx.py sa3-m` (unchanged invocation). They **must** be built `STRONGLY_TYPED` — weakly-typed + `BuilderFlag.FP16` fuses and runs just as fast but lets TRT re-cast the FP32 RMSNorm islands, i.e. silently degrades to naive FP16 (measured: teacher-forced cos 0.88 @L=256, 0.77 @L=4092). This is the opposite of the fp8-GEMM recipe, where weakly-typed is required; the rule is per-pattern.
- `--no-bound-attn` skips the new pass and reproduces the pre-2026-07 graph.
- Only the medium DiT's shipped engines are affected. `sa3-sm-music` / `sa3-sm-sfx` use standard (non-differential) attention and their RoPE island already terminates before QK^T — verified at the ONNX level: their QK^T operands are FP16, which is why they already fuse 40/40 MHA. Their published ONNX and engines are unchanged by this PR. Note that re-running the producer for them *would* also move their softmax island into FP16 (40/40 convert); that is untested and unshipped, so use `--no-bound-attn` if the goal is to reproduce their published graphs.

## Not in this PR

- **`sa3-m/dit_bf16.trt` is unchanged and still drifts at long sequence.** A corrected bf16 engine (fp32 angle island, or baked RoPE tables) is deferred to separate work.
- **FAD/CLAP perceptual validation at n=128 has not landed.** Everything above is latent-space fidelity (teacher-forced velocity cosine, latent std ratio vs the per-card fp32 reference), amplitude metrics on full-length renders, and spot listening across 3 prompts × 3 lengths. That is a narrower bar than the `dit_bf16` release cleared. A run is in progress; **do not merge on quality grounds until it reports.**
- **Pipeline-mode coverage is partial.** Text-to-audio and varlen are exercised against the new engines; CFG, audio-to-audio and inpaint have not been re-tested. That work is in progress too.
- No benchmarking was re-run for this PR's own docs: the end-to-end "Speed & memory" table in `optimized/tensorRT/README.md` still carries its older H100 pipeline numbers, which were measured with the previous medium default.

## Verification run here

CPU-only (no GPU touched): `ast.parse` on all six changed Python files; `--help` renders for `sa3_trt.py`, `sa3_trt_core.py` and `build_dit_fp16mixed.py`; `default_precision()` returns `fp16mixed` for `medium`/`sm-music`/`sm-sfx`; all three precisions resolve through `get_dit_engine_path('medium', p)` and `bf16` is still correctly rejected for the small DiTs; `DIT_ENGINE_FILES` / `DIT_CHOICES` / `get_engine_files()` agree with the new default. The new pass was also replayed against the real published graphs with weights unloaded: 96/96 attentions convert on `sa3-m/dit_fp16mixed.onnx` (40/40 on `sa3-sm-music`), no softmax output left declared FP32, and the graph's pre-existing node-ordering slack decreases rather than grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
