### PR TITLE
tensorRT: fix cross-stream race in the TRT call helpers (silent wrong audio on the default medium config)

### DIFF
--- a/optimized/tensorRT/scripts/sa3_trt_core.py
+++ b/optimized/tensorRT/scripts/sa3_trt_core.py
@@ -414,6 +414,36 @@ class TRTRunner:
         torch.cuda.empty_cache()
 
 
+def _run_engine(runner: "TRTRunner", ctx, what: str) -> None:
+    """Enqueue TRT on the runner's private stream, correctly ordered against the caller.
+
+    Every input buffer these helpers bind is produced on the CURRENT stream — a
+    `.to(dtype)` cast, a `.contiguous()` copy, a `.cuda()` transfer, or the caller's
+    own compute — while TRT is enqueued on `runner.stream`. CUDA gives no ordering
+    between two streams unless you ask for it, so without the `wait_stream()` below
+    the engine may start reading those buffers before the producing work has
+    finished. That is a data race, and its failure mode here is silent: the engine
+    consumes whatever happens to be in memory and returns a plausible-looking
+    tensor, so a partially-written latent decodes to subtly (or completely) wrong
+    audio with no error anywhere.
+
+    The trailing host-side `synchronize()` is what makes the OUTPUT safe to read.
+    It also means the caching allocator cannot recycle either buffer while the
+    engine is still using it — both stay referenced by the calling frame until
+    after the sync returns — so `record_stream()` is not needed on top.
+
+    The return value of `execute_async_v3` is checked because a failed enqueue
+    otherwise leaves the output buffer untouched, which reads downstream as
+    digital silence rather than as an error.
+    """
+    runner.stream.wait_stream(torch.cuda.current_stream())
+    if not ctx.execute_async_v3(runner.stream.cuda_stream):
+        raise RuntimeError(
+            f"{what}: TRT execute_async_v3 failed to enqueue. The output buffer is "
+            f"unwritten — treat any audio produced from it as invalid.")
+    runner.stream.synchronize()
+
+
 # ─── TRT call helpers (one per engine type) ──────────────────────────────
 def t5gemma_encode(runner: TRTRunner, tokenizer, prompt: str):
     """Run T5Gemma TRT. Returns (embeds (1, 256, 768), mask (1, 256))."""
@@ -429,7 +459,7 @@ def t5gemma_encode(runner: TRTRunner, tokenizer, prompt: str):
     ctx.set_tensor_address("input_ids", ids.data_ptr())
     ctx.set_tensor_address("attention_mask", mask.data_ptr())
     ctx.set_tensor_address("hidden_states", out.data_ptr())
-    ctx.execute_async_v3(runner.stream.cuda_stream); runner.stream.synchronize()
+    _run_engine(runner, ctx, "t5gemma_encode")
     return out.float(), mask
 
 
@@ -454,7 +484,7 @@ def encoder_encode(runner: TRTRunner, audio: torch.Tensor) -> torch.Tensor:
     out = torch.empty(out_shape, dtype=out_dt, device="cuda")
     ctx.set_tensor_address("audio", a.data_ptr())
     ctx.set_tensor_address("latent", out.data_ptr())
-    ctx.execute_async_v3(runner.stream.cuda_stream); runner.stream.synchronize()
+    _run_engine(runner, ctx, "encoder_encode")
     return out.float()
 
 
@@ -557,7 +587,7 @@ def decoder_decode(runner: TRTRunner, latents: torch.Tensor) -> torch.Tensor:
     out = torch.empty(out_shape, dtype=out_dt, device="cuda")
     ctx.set_tensor_address("latent", lat.data_ptr())
     ctx.set_tensor_address(out_name, out.data_ptr())
-    ctx.execute_async_v3(runner.stream.cuda_stream); runner.stream.synchronize()
+    _run_engine(runner, ctx, "decoder_decode")
     if out.dtype in (torch.float16, torch.bfloat16, torch.float32):
         return out.float()
     return out


### PR DESCRIPTION
Fixes **P2** from the mode-coverage sweep. Pre-existing — reproduces identically on the previously published engine, and predates the fp16-mixed rebuild.

## The bug

`t5gemma_encode`, `encoder_encode` and `decoder_decode` each bind input buffers produced on the **current** stream — a `.to(dtype)` cast, a `.contiguous()` copy, a `.cuda()` transfer, or the caller's own compute — then enqueue TRT on the runner's **private** stream:

```python
ctx.execute_async_v3(runner.stream.cuda_stream); runner.stream.synchronize()
```

CUDA gives no ordering between two streams unless you ask for it, so the engine could start reading those buffers before the work writing them had finished. The trailing `synchronize()` makes the **output** safe to read but does nothing for the **input**.

The failure is silent: TRT consumes whatever is in memory and returns a plausible-looking tensor, so a partially-written latent decodes to wrong audio with **no error and exit code 0**. It hits the default `--dit medium` + `--decoder same-l` path.

## The fix

All three route through a shared `_run_engine()` that waits on the producing stream first, and checks the `execute_async_v3` return value — a failed enqueue previously left the output buffer untouched, which reads downstream as digital silence rather than as an error. (That is very likely the mechanism behind the ~5% digital-silence rate seen on 380 s sm_120 renders, where the card sits near 0 GiB free.)

`record_stream()` is deliberately **not** added: both buffers stay referenced by the calling frame until after the host-side `synchronize()`, so the caching allocator cannot recycle them early.

## Verification

Provoked the race directly (`verify_p2_fix.py`, SAME-L decoder, L=1292, sm_120). With the latent's final write left queued behind a low-occupancy delay on the current stream:

| arm | trials returning wrong audio |
|---|---|
| old path (no `wait_stream`) | **19 / 20** — max \|diff\| 2.3e4 on int16 PCM |
| fixed path | **0 / 20** |

Worth noting for anyone reproducing: a **heavy-compute** delay does *not* provoke it. Saturating every SM makes the hardware serialise the race away — my first attempt was 0/20 and proved nothing. The delay has to be long and low-occupancy (`torch.cuda._sleep`) so the consumer's kernels can actually get scheduled early. That is likely why this went unnoticed.

End-to-end smoke test after the fix: 6 renders (3 prompts × eager/TRT) at L=1292 through the full T5 → DiT → SAME-L pipeline, all sane, TRT tracking eager to ~0.01% clipping and ~0.01 crest.

## Still open from that sweep

P3 (SAME-L not CUDA-graph-capturable on sm_120), P4 (double engine load on the eager path, ~2× peak VRAM), P5 (`L < 32` not validated against the decoder profile → exit 0 + digital silence). Detail in `MODE_COVERAGE.md`. P1 (CFG no-op) was fixed in #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)