### PR TITLE
tensorRT: block-tiled MMA kernel for the SAME-L SWA plugin, and document the AOT/JIT choice

### DIFF
--- a/optimized/tensorRT/README.md
+++ b/optimized/tensorRT/README.md
@@ -184,8 +184,10 @@ JIT-dispatched build is not stream-capturable: the decode is silently dropped fr
 graph and every render comes back as the same wash of noise, with exit code 0.
 
 If you see byte-identical output across seeds, you are on an affected engine. Re-pull it
-(the published files were rebuilt 2026-07-31), or run with `--no-mega-graph` to bypass
-capture. Building your own is covered under "Choosing the SAME-L attention kernel" in
+(the published `sm_120` engines were rebuilt 2026-07-31), or run with `--no-mega-graph` to
+bypass capture. The `sm_90` engines are unaffected and still ship the JIT kernel, which is
+why **Triton is required at inference on sm_90 but not on sm_120**. Building your own is
+covered under "Choosing the SAME-L attention kernel" in
 [`build/README.md`](build/README.md).
 
 ## Speed & memory

--- a/optimized/tensorRT/README.md
+++ b/optimized/tensorRT/README.md
@@ -175,6 +175,19 @@ Omit `--dit` / `--decoder` for an interactive arrow-key picker. Relative
 The TRT DiT engines are static batch=1 (the ONNX bakes batch=1), so CFG runs as a
 sequential cond+uncond dual-pass at batch=1 for every precision.
 
+### SAME-L attention kernel
+
+`--decoder same-l` uses a custom sliding-window-attention plugin. Prebuilt engines embed
+an ahead-of-time PTX kernel, so nothing re-enters Python during inference and the engine
+goes inside the full-pipeline CUDA graph. This matters on **sm_120**, where the older
+JIT-dispatched build is not stream-capturable: the decode is silently dropped from the
+graph and every render comes back as the same wash of noise, with exit code 0.
+
+If you see byte-identical output across seeds, you are on an affected engine. Re-pull it
+(the published files were rebuilt 2026-07-31), or run with `--no-mega-graph` to bypass
+capture. Building your own is covered under "Choosing the SAME-L attention kernel" in
+[`build/README.md`](build/README.md).
+
 ## Speed & memory
 
 Measured on **H100 SXM 80 GB** at `--steps 8` (rf-denoiser sweet spot).

--- a/optimized/tensorRT/build/README.md
+++ b/optimized/tensorRT/build/README.md
@@ -81,6 +81,80 @@ python build_from_onnx.py all-both              # canonical + FP32
 
 That's it — no `stable-audio-tools`, no `transformers`, no model checkpoints.
 
+## Choosing the SAME-L attention kernel
+
+The SAME-L encoder/decoder use a custom sliding-window-attention plugin
+(`samel::diff_attn_swa`). It ships **two implementations**, and which one the engine uses
+is decided at build time and baked into the `.trt`. If you are bringing up an
+architecture we have not published engines for, this is the one knob you may have to
+touch.
+
+```bash
+SA3_SWA_PLUGIN=aot   # default. PTX kernel compiled into the engine.
+SA3_SWA_PLUGIN=jit   # Triton dispatched through a Python callback per enqueue.
+SA3_SWA_AOT=mma      # default AOT kernel: block-tiled, tensor cores.
+SA3_SWA_AOT=ptx      # fallback AOT kernel: scalar FP32, one warp per query.
+```
+
+| | AOT (`mma`) | JIT |
+|---|---|---|
+| CUDA-graph capturable | **yes** | yes on sm_90, **no on sm_120** |
+| Python/Triton callbacks per decode | **0** | 12 (one per attention layer) |
+| Needs torch + Triton at inference | no | **yes** |
+| Engine size | +0.1% | baseline |
+| Build-time deps | Triton | Triton |
+
+### Why AOT is the default
+
+**Correctness on sm_120.** A JIT engine is not stream-capturable there: `enqueueV3`
+returns `False` under capture, TRT reports *"this TRT engine is not stream capturable"*,
+and the stage is **silently omitted** from the graph. The decoder then returns the
+pre-capture warmup decode of zero latents — a constant wash of noise, byte-identical
+across seeds and prompts, with **exit code 0**. It captures fine on sm_90, but
+re-entering Python inside a captured region is fragile rather than supported, so do not
+assume a new architecture will tolerate it.
+
+**Robustness.** AOT removes 12 GIL acquisitions per decode, which matters for
+concurrent serving, and removes the runtime Triton dependency entirely.
+
+### Measured (SAME-L decode, ms, median of 7 on an idle GPU)
+
+| sm_120 · RTX PRO 4500 | L=256 | L=1024 | L=1292 | L=2048 | L=4096 |
+|---|---|---|---|---|---|
+| JIT | 55.1 | 227.2 | 289.1 | 457.7 | 920.2 |
+| AOT `ptx` | 62.5 | 251.2 | 318.7 | 502.8 | 1008.8 |
+| **AOT `mma`** | 55.4 | **223.6** | **283.7** | **448.4** | **899.3** |
+
+| sm_90 · H200 | L=256 | L=1024 | L=1292 | L=2048 | L=4096 |
+|---|---|---|---|---|---|
+| JIT | 12.4 | 47.0 | 61.1 | 98.5 | 194.4 |
+| AOT `ptx` | 12.7 | 47.3 | 60.7 | 96.6 | 195.5 |
+| **AOT `mma`** | 12.4 | 48.4 | 62.6 | 100.0 | 196.8 |
+
+Accuracy against the FP32 decoder at L=1292 on sm_120: AOT `mma` **51.45 dB**, JIT
+51.43, AOT `ptx` 51.11 — the MMA kernel is the most accurate of the three.
+
+So `mma` is at parity with JIT on both architectures (a few percent either way, faster
+at long sequence on sm_120) while being capturable. `ptx` costs ~10% on sm_120 and is
+kept only as a fallback if the MMA kernel will not build on some future target.
+
+### If you are bringing up a new architecture
+
+1. Build with the defaults and **check the decoder output is not constant** — render two
+   different seeds and compare. Identical output is the non-capturable-engine signature
+   described above, not a sampling quirk.
+2. If the AOT build fails, try `SA3_SWA_AOT=ptx` (simpler kernel, no shared-memory or
+   tensor-core requirements), then `SA3_SWA_PLUGIN=jit` as a last resort — and if you
+   land on `jit`, verify capture explicitly rather than trusting it.
+3. Two AOT constraints that bite on new targets:
+   - The MMA kernel needs **40 KB of shared memory**. `BLOCK_N=64` would need 64 KB,
+     over the 48 KB static limit, and fails at enqueue with *"Failed to enqueue status
+     -1"*. If a target has less shared memory, lower `BLOCK_N` in
+     `scripts/triton_diff_swa_mma.py` — but keep `BLOCK_KV >= BLOCK_N + 2*WINDOW`, or the
+     K/V tile stops covering the window and attention contributions are silently dropped.
+   - The PTX `.target` is rewritten to the plain `sm_XX` (Triton emits `sm_XXa`, which
+     TRT's loader rejects). The `m16n8k8` TF32 `mma` used here needs sm_80+.
+
 ## Publishing TRT engines to HuggingFace
 
 After building all 8 engines for a new `<arch>`, push them to HF so others on the same GPU don't need to rebuild:

--- a/optimized/tensorRT/build/README.md
+++ b/optimized/tensorRT/build/README.md
@@ -104,6 +104,21 @@ SA3_SWA_AOT=ptx      # fallback AOT kernel: scalar FP32, one warp per query.
 | Engine size | +0.1% | baseline |
 | Build-time deps | Triton | Triton |
 
+### What the published engines use
+
+| published engines | kernel |
+|---|---|
+| `sm_120/same-l/` | AOT (block-tiled MMA) — required, see below |
+| `sm_90/same-l/` | JIT — predates the AOT kernel, captures fine on Hopper, and AOT measured no faster there, so they were left alone |
+
+Building `same-l` for sm_90 today gives you AOT rather than the published JIT engine. That
+is fine — the two are at parity in speed and AOT is the more robust of the pair — but it
+does mean your local engine will not be byte-identical to the downloaded one.
+
+The runtime registers both implementations, so a JIT engine and an AOT engine both load
+and run whatever GPU you are on. Verified: the published sm_90 JIT engine produces
+byte-identical output before and after the AOT implementation was added.
+
 ### Why AOT is the default
 
 **Correctness on sm_120.** A JIT engine is not stream-capturable there: `enqueueV3`

--- a/optimized/tensorRT/build/build.py
+++ b/optimized/tensorRT/build/build.py
@@ -59,10 +59,14 @@ TARGETS = [
     {"label": "same-s decoder",
      "command": _from_onnx("same-s-decoder"),
      "outputs": ["same-s/dec_dynamic_bf16.trt"]},
-    {"label": "same-l encoder (Triton SWA plugin, FP16-mixed)",
+    # SAME-L uses the custom SWA plugin. Its kernel implementation is chosen at build
+    # time via SA3_SWA_PLUGIN / SA3_SWA_AOT and baked into the engine — the default (AOT
+    # block-tiled MMA) is graph-capturable and needs no Python at inference. See
+    # "Choosing the SAME-L attention kernel" in README.md before overriding.
+    {"label": "same-l encoder (SWA plugin — AOT MMA kernel, graph-capturable)",
      "command": _from_onnx("same-l-encoder"),
      "outputs": ["same-l/enc_dynamic_triton_swa.trt"]},
-    {"label": "same-l decoder (Triton SWA plugin, FP16-mixed)",
+    {"label": "same-l decoder (SWA plugin — AOT MMA kernel, graph-capturable)",
      "command": _from_onnx("same-l-decoder"),
      "outputs": ["same-l/dec_dynamic_triton_swa.trt"]},
     # DiT engines now build from pre-processed FP16-mixed ONNX on HF;

--- a/optimized/tensorRT/build/build_from_onnx.py
+++ b/optimized/tensorRT/build/build_from_onnx.py
@@ -34,11 +34,6 @@ from _arch import detect_arch, arch_dir  # noqa: E402
 HF_REPO = "stabilityai/stable-audio-3-optimized"
 HF_ONNX_PREFIX = "onnx"  # files at HF_REPO/onnx/<engine_subdir>/<file>.onnx
 
-# Architectures where the JIT (Triton) plugin path produces a non-stream-capturable
-# engine, so the AOT PTX path must be used instead. Everywhere else JIT is preferred
-# because it is measurably faster. See the plugin-preference block in build_one().
-_AOT_PLUGIN_ARCHES = {"sm_120"}
-
 T5_TOKENS = 256
 T5_HIDDEN_DIM = 768
 SAMPLES_PER_LATENT = 4096
@@ -464,30 +459,26 @@ def build_one(name: str) -> str:
         #   "Plugin 'samel::diff_attn_swa' has both AOT and JIT implementations.
         #    PREFER_AOT_PYTHON_PLUGINS or PREFER_JIT_PYTHON_PLUGINS should be specified."
         #
-        # The choice is per-arch because neither wins outright, measured on the SAME-L
-        # decoder at L=1292:
+        # Always AOT. With the block-tiled MMA kernel (swa_mma_aot) AOT is within a
+        # few percent of JIT on both architectures, and it is the only correct option
+        # on sm_120, where a JIT engine is not stream-capturable — enqueueV3 returns
+        # False under capture, the decode is silently dropped from the mega-graph, and
+        # every render returns the warmup decode of zero latents.
         #
-        #   sm_120  JIT engine is NOT stream-capturable. enqueueV3 returns False under
-        #           capture, the decode is silently dropped from the mega-graph, and
-        #           every render returns the warmup decode of zero latents (a constant
-        #           wash, identical across seeds, exit code 0). AOT is the only correct
-        #           option here, and it restores the mega-graph fast path.
-        #   sm_90   JIT captures fine AND is 24% faster (55.0 ms vs AOT's best 68.2 ms).
-        #           The gap is algorithmic, not tuning: the Triton kernel block-tiles
-        #           queries sharing K/V in SRAM and uses tl.dot for tensor cores, while
-        #           the PTX kernel is one warp per query, scalar FP32, no K/V reuse.
-        #           Sweeping its only knob (warps_per_block) across 1..16 moves it 7%
-        #           and never closes the gap. So AOT would be a pure 24% loss here.
-        if detect_arch() in _AOT_PLUGIN_ARCHES:
-            net_flags |= 1 << int(
-                trt.NetworkDefinitionCreationFlag.PREFER_AOT_PYTHON_PLUGINS)
-            print(f"  plugin impl: AOT (required on {detect_arch()} for graph capture)",
-                  flush=True)
-        else:
-            net_flags |= 1 << int(
-                trt.NetworkDefinitionCreationFlag.PREFER_JIT_PYTHON_PLUGINS)
-            print(f"  plugin impl: JIT (captures on {detect_arch()} and is faster)",
-                  flush=True)
+        # AOT is also the more robust runtime: the JIT path re-enters Python 12 times
+        # per decode (once per attention layer), each acquiring the GIL and dispatching
+        # into Triton. AOT does none of that — the kernel is compiled into the engine —
+        # and it costs +0.1% engine size.
+        #
+        # An earlier revision made this per-arch on the strength of a claimed 24%
+        # AOT penalty on sm_90. That measurement was wrong (CUDA events recorded on the
+        # default stream while the work ran on the runner's private stream); re-measured
+        # correctly the hand-written kernel is ~equal to JIT on sm_90, and the MMA kernel
+        # is ~equal on both. Set SA3_SWA_AOT=ptx to fall back to the hand-written kernel.
+        net_flags |= 1 << int(
+            trt.NetworkDefinitionCreationFlag.PREFER_AOT_PYTHON_PLUGINS)
+        print("  plugin impl: AOT (graph-capturable, no Python in the enqueue path)",
+              flush=True)
     network = builder.create_network(net_flags)
     parser = trt.OnnxParser(network, logger)
     if not parser.parse_from_file(onnx_path):

--- a/optimized/tensorRT/build/build_from_onnx.py
+++ b/optimized/tensorRT/build/build_from_onnx.py
@@ -8,6 +8,17 @@ stabilityai/stable-audio-3-optimized/onnx/.
 To rebuild engines for a new GPU arch (sm_100, sm_120, ...) you run this on
 that GPU and TRT bakes the arch into the engine.
 
+SAME-L attention kernel: the SWA plugin ships two implementations and the choice is
+baked into the engine at build time. AOT (default) compiles a block-tiled tensor-core
+PTX kernel in, so nothing re-enters Python at inference and the engine can be captured
+into a CUDA graph. JIT dispatches to Triton through a Python callback on every enqueue.
+If you are bringing up a new architecture and the decoder produces a constant wash of
+noise, or silence, read "Choosing the SAME-L attention kernel" in build/README.md before
+anything else — that is the signature of a non-capturable engine inside the mega-graph.
+
+    SA3_SWA_PLUGIN=aot|jit   which implementation the engine uses (default aot)
+    SA3_SWA_AOT=mma|ptx      which AOT kernel, if AOT (default mma)
+
 Usage:
     python build_from_onnx.py t5gemma
     python build_from_onnx.py same-s-encoder
@@ -459,26 +470,22 @@ def build_one(name: str) -> str:
         #   "Plugin 'samel::diff_attn_swa' has both AOT and JIT implementations.
         #    PREFER_AOT_PYTHON_PLUGINS or PREFER_JIT_PYTHON_PLUGINS should be specified."
         #
-        # Always AOT. With the block-tiled MMA kernel (swa_mma_aot) AOT is within a
-        # few percent of JIT on both architectures, and it is the only correct option
-        # on sm_120, where a JIT engine is not stream-capturable — enqueueV3 returns
-        # False under capture, the decode is silently dropped from the mega-graph, and
-        # every render returns the warmup decode of zero latents.
-        #
-        # AOT is also the more robust runtime: the JIT path re-enters Python 12 times
-        # per decode (once per attention layer), each acquiring the GIL and dispatching
-        # into Triton. AOT does none of that — the kernel is compiled into the engine —
-        # and it costs +0.1% engine size.
-        #
-        # An earlier revision made this per-arch on the strength of a claimed 24%
-        # AOT penalty on sm_90. That measurement was wrong (CUDA events recorded on the
-        # default stream while the work ran on the runner's private stream); re-measured
-        # correctly the hand-written kernel is ~equal to JIT on sm_90, and the MMA kernel
-        # is ~equal on both. Set SA3_SWA_AOT=ptx to fall back to the hand-written kernel.
-        net_flags |= 1 << int(
-            trt.NetworkDefinitionCreationFlag.PREFER_AOT_PYTHON_PLUGINS)
-        print("  plugin impl: AOT (graph-capturable, no Python in the enqueue path)",
-              flush=True)
+        # Two implementations of the SAME-L SWA plugin exist and the engine bakes in
+        # whichever this build prefers. Default AOT; override with SA3_SWA_PLUGIN=jit.
+        # See "Choosing the SAME-L attention kernel" in build/README.md.
+        want = os.environ.get("SA3_SWA_PLUGIN", "aot").lower()
+        if want not in ("aot", "jit"):
+            sys.exit(f"SA3_SWA_PLUGIN must be 'aot' or 'jit', got {want!r}")
+        if want == "aot":
+            net_flags |= 1 << int(
+                trt.NetworkDefinitionCreationFlag.PREFER_AOT_PYTHON_PLUGINS)
+            print("  plugin impl: AOT — graph-capturable, no Python in the enqueue "
+                  "path (SA3_SWA_PLUGIN=jit to switch)", flush=True)
+        else:
+            net_flags |= 1 << int(
+                trt.NetworkDefinitionCreationFlag.PREFER_JIT_PYTHON_PLUGINS)
+            print("  plugin impl: JIT — Triton at runtime. NOT stream-capturable on "
+                  "sm_120; verify before shipping (see build/README.md)", flush=True)
     network = builder.create_network(net_flags)
     parser = trt.OnnxParser(network, logger)
     if not parser.parse_from_file(onnx_path):

--- a/optimized/tensorRT/scripts/diff_attn_nocast_plugin.py
+++ b/optimized/tensorRT/scripts/diff_attn_nocast_plugin.py
@@ -25,6 +25,8 @@ SAME-L decoder: FP32 in/out, q/k/v each (B, N, 2H, D) = (1, 4352, 48, 64), D=64,
 2H=48 so H=24, window=17. It performs the differential subtraction in FP32 inside
 the kernel, which is also what the Triton path does via o[:, :, :H] - o[:, :, H:].
 """
+import os
+
 import torch
 import tensorrt.plugin as trtp
 from typing import Tuple
@@ -35,6 +37,15 @@ WINDOW = 17
 HEAD_DIM = 64
 WARPS_PER_BLOCK = 4
 _ptx_cache: dict = {}
+
+# Which AOT kernel to compile into the engine:
+#   "mma"  block-tiled Triton-compiled kernel with tensor cores (swa_mma_aot).
+#          BLOCK_N queries per block sharing the K/V window in SRAM; ~3.6x faster per
+#          layer than "ptx" and on par with the JIT path.
+#   "ptx"  the original hand-written scalar-FP32 kernel (diff_swa_ptx_kernel): one warp
+#          per query, no K/V reuse, zero mma instructions.
+# Both are graph-capturable; this only trades speed. Override with SA3_SWA_AOT.
+SWA_AOT_BACKEND = os.environ.get("SA3_SWA_AOT", "mma").lower()
 
 
 def _ptx_for(num_heads: int):
@@ -90,13 +101,32 @@ def diff_attn_swa_aot(q_bat: trtp.TensorDesc, k_bat: trtp.TensorDesc,
     position for head h and head h+H, subtracting in FP32 before the store. Strides
     are passed as symbolic extras so the kernel works across the dynamic N axis.
     """
-    name, ptx = _ptx_for(num_heads)
     B = q_bat.shape_expr[0]
     N = q_bat.shape_expr[1]
     H2 = q_bat.shape_expr[2]
     D = q_bat.shape_expr[3]
     H_out = H2 // 2
 
+    if SWA_AOT_BACKEND == "mma":
+        # Block-tiled tensor-core kernel. Its scalars are baked in as constexprs at
+        # compile time, so the only runtime extra is N. Grid is one block per
+        # (query tile, output head, batch); shared memory holds the Q/K/V tiles.
+        import swa_mma_aot
+        from _arch import detect_arch
+        name, ptx, shared, warps = swa_mma_aot.build(num_heads, detect_arch())
+        extra = trtp.SymIntExprs(1)
+        extra[0] = N
+        return (name, ptx,
+                trtp.KernelLaunchParams(
+                    grid_x=trtp.cdiv(N, swa_mma_aot.BLOCK_N),
+                    grid_y=H_out,
+                    grid_z=B,
+                    block_x=warps * 32,
+                    shared_mem=shared),
+                extra)
+
+    # Hand-written scalar kernel: one warp per query, strides passed at runtime.
+    name, ptx = _ptx_for(num_heads)
     extra = trtp.SymIntExprs(5)
     extra[0] = N
     extra[1] = H2 * D        # stride between positions, input

--- a/optimized/tensorRT/scripts/swa_mma_aot.py
+++ b/optimized/tensorRT/scripts/swa_mma_aot.py
@@ -1,0 +1,115 @@
+"""Triton-compiled block-tiled MMA kernel, packaged as AOT PTX for trtp.aot_impl.
+
+The SAME-L SWA plugin needs an ahead-of-time kernel so its TRT engine is
+CUDA-graph-capturable. The existing AOT kernel (diff_swa_ptx_kernel.py) is hand-written
+scalar-FP32 PTX — one warp per query, no K/V reuse, zero mma instructions — and is ~3.6x
+slower per layer than the Triton JIT path, which across the decoder's 12 attention
+layers accounts for the whole 55 -> 68 ms engine-level gap on sm_90.
+
+This module closes that gap by compiling triton_diff_swa_mma's block-tiled kernel
+ahead of time and exposing its PTX. Using Triton as the code generator rather than
+hand-writing mma fragment layouts is deliberate: it already emits exactly the wanted
+codegen (verified: 512 x mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32), and PTX
+MMA fragment register assignment is error-prone to write by hand.
+
+Two things have to be reconciled with what trtp.aot_impl can actually pass a kernel:
+
+  1. The `extra` channel carries INT32s only, so every non-int runtime scalar must be a
+     constexpr. `scale` (fp32), `H_OUT`, `WINDOW`, the block sizes and 15 of the 16
+     strides are therefore pinned at compile time, leaving only `N` at runtime.
+  2. Triton appends two global-scratch pointers to the entry signature. TRT passes
+     input/output pointers plus the extras and has no channel for them — but they are
+     DECLARED AND NEVER LOADED (checked: only the declaration mentions them, there is no
+     ld.param), so they are stripped from the PTX entry signature. That makes the
+     kernel's declared parameter space exactly match what TRT supplies, rather than
+     relying on the driver tolerating a short argument list.
+"""
+import re
+
+import triton
+from triton.compiler.compiler import ASTSource
+
+from triton_diff_swa_mma import (diff_swa_mma_kernel, WINDOW, BLOCK_N, BLOCK_D,
+                                 BLOCK_KV)
+
+HEAD_DIM = BLOCK_D
+_cache: dict = {}
+
+
+def _strip_unused_tail_params(ptx: str, keep: int) -> str:
+    """Remove entry parameters after the first `keep`, asserting they are unread.
+
+    Triton's trailing global-scratch pointers have no channel through aot_impl. They
+    are never dereferenced, so dropping the declarations is safe — but verify that
+    before cutting, so this fails loudly if a future Triton starts using them.
+    """
+    m = re.search(r"(\.visible \.entry \w+\()([^)]*)(\))", ptx, re.S)
+    if m is None:
+        raise RuntimeError("could not locate the PTX entry signature")
+    params = [p.strip() for p in m.group(2).split(",") if p.strip()]
+    if len(params) <= keep:
+        return ptx
+    for p in params[keep:]:
+        name = p.split()[-1]
+        if re.search(rf"ld\.param[^\n]*\[{re.escape(name)}\]", ptx):
+            raise RuntimeError(
+                f"refusing to strip {name}: it IS loaded by the kernel, so TRT must "
+                f"pass it and this packaging is invalid")
+    new_sig = ",\n\t".join(params[:keep])
+    return ptx[:m.start()] + m.group(1) + "\n\t" + new_sig + "\n" + m.group(3) + ptx[m.end():]
+
+
+def build(num_heads: int, arch: str):
+    """(kernel_name, ptx, shared_mem_bytes, num_warps) for this head count.
+
+    `arch` is the sm_XX being built for; the PTX `.target` is rewritten to it without
+    the trailing 'a' (architecture-specific) suffix, which TRT's loader rejects. The
+    m16n8k8 TF32 mma this kernel uses is available from sm_80, so the plain target is
+    sufficient.
+    """
+    key = (num_heads, arch)
+    if key in _cache:
+        return _cache[key]
+
+    h2 = 2 * num_heads
+    # Order must match the kernel: inputs, then the runtime extra, then outputs.
+    sig = {"Q": "*fp32", "K": "*fp32", "V": "*fp32", "N": "i32", "Out": "*fp32"}
+    sig.update({f"stride_{t}{a}": "constexpr" for t in "qkvo" for a in "bnhd"})
+    sig.update({"scale": "constexpr", "H_OUT": "constexpr",
+                "WINDOW": "constexpr", "BLOCK_N": "constexpr",
+                "BLOCK_D": "constexpr", "BLOCK_KV": "constexpr"})
+    # Contiguous (B, N, 2H, D) in and (B, N, H, D) out. The batch strides are only ever
+    # multiplied by program_id(2), which is 0 for the decoder's batch of 1, so pinning
+    # them to 0 is exact here rather than an approximation.
+    consts = {
+        "stride_qb": 0, "stride_qn": h2 * HEAD_DIM, "stride_qh": HEAD_DIM, "stride_qd": 1,
+        "stride_kb": 0, "stride_kn": h2 * HEAD_DIM, "stride_kh": HEAD_DIM, "stride_kd": 1,
+        "stride_vb": 0, "stride_vn": h2 * HEAD_DIM, "stride_vh": HEAD_DIM, "stride_vd": 1,
+        "stride_ob": 0, "stride_on": num_heads * HEAD_DIM, "stride_oh": HEAD_DIM,
+        "stride_od": 1,
+        "scale": HEAD_DIM ** -0.5, "H_OUT": num_heads, "WINDOW": WINDOW,
+        "BLOCK_N": BLOCK_N, "BLOCK_D": BLOCK_D, "BLOCK_KV": BLOCK_KV,
+    }
+    try:
+        src = ASTSource(diff_swa_mma_kernel, signature=sig, constexprs=consts)
+    except TypeError:                     # older Triton spells it `constants`
+        src = ASTSource(diff_swa_mma_kernel, signature=sig, constants=consts)
+
+    compiled = triton.compile(src)
+    ptx = compiled.asm["ptx"]
+    md = compiled.metadata
+
+    n_mma = len(re.findall(r"mma\.sync", ptx))
+    if n_mma == 0:
+        raise RuntimeError("compiled PTX has no mma instructions — tl.dot did not "
+                           "lower to tensor cores; the kernel would be no faster than "
+                           "the scalar hand-written one")
+
+    # TRT passes: Q, K, V (inputs), Out (output), then the extras. One extra (N).
+    ptx = _strip_unused_tail_params(ptx, keep=5)
+    ptx = re.sub(r"\.target\s+sm_\w+", f".target {arch}", ptx)
+    # fp32 loads need 4-byte alignment; Triton emits .align 1 on the pointer params.
+    ptx = ptx.replace(".align 1 .b8", ".align 4 .b8")
+
+    _cache[key] = (md.name, ptx, int(md.shared), int(md.num_warps))
+    return _cache[key]

--- a/optimized/tensorRT/scripts/triton_diff_swa_mma.py
+++ b/optimized/tensorRT/scripts/triton_diff_swa_mma.py
@@ -1,0 +1,170 @@
+"""Block-tiled differential SWA attention in Triton, shaped for AOT compilation.
+
+Why this exists
+---------------
+The SAME-L decoder's SWA plugin needs an ahead-of-time (PTX) implementation so its TRT
+engine is CUDA-graph-capturable — the JIT path re-enters Python per enqueue, which
+makes the engine non-capturable on sm_120 and silently drops the decode from the
+mega-graph. The existing AOT kernel (diff_swa_ptx_kernel.py) is hand-written PTX that
+is one warp per query, scalar FP32, no K/V reuse, and emits zero mma instructions —
+24% slower than the Triton JIT path on sm_90, and sweeping its only knob
+(warps_per_block over 1..16) moves it 7%, so the gap is algorithmic.
+
+This module supplies the missing algorithm: BLOCK_N queries per block sharing the K/V
+window in SRAM, with tl.dot so QK^T and P·V land on tensor cores. Compiling it with
+triton.compile() yields PTX containing mma.sync instructions, which can then be handed
+to trtp.aot_impl — Triton's own codegen instead of hand-written fragment layouts.
+
+The one substantive difference from triton_swa_v2.swa_attn_v2_kernel: that kernel
+computes all 2H heads and leaves the differential subtraction to the caller
+(o[:, :, :H] - o[:, :, H:]) in PyTorch. aot_impl returns a SINGLE kernel, so there is
+no caller to do that — the subtraction has to happen inside. Each block therefore owns
+one OUTPUT head h and processes two input heads, h (primary) and h + H (diff),
+subtracting before the store. That also saves materialising a 2H-head intermediate.
+
+Precision note: tl.dot on fp32 inputs lowers to TF32 mma (10 mantissa bits), which is
+what the existing Triton path already does. The subtraction itself stays in FP32 on
+FP32 accumulator values, so the cancellation-sensitive step is unaffected — only the
+two attention products are TF32, exactly as in the shipped JIT path.
+"""
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def diff_swa_mma_kernel(
+    # PARAMETER ORDER IS LOAD-BEARING: TRT's AOT plugin launcher passes
+    #   inputs..., extras..., outputs...
+    # (confirmed against the working hand-written kernel in diff_swa_ptx_kernel.py,
+    # whose entry is Q, K, V, N, 4 strides, Out — output LAST, after the extras).
+    # An earlier version declared (Q, K, V, Out, N) and TRT therefore handed N where
+    # the kernel expected the output pointer: it dereferenced 4352 as an address and
+    # the engine died with "illegal memory access". Runtime scalars must sit between
+    # the inputs and the outputs.
+    Q, K, V,
+    N,
+    Out,
+    stride_qb, stride_qn, stride_qh, stride_qd,
+    stride_kb, stride_kn, stride_kh, stride_kd,
+    stride_vb, stride_vn, stride_vh, stride_vd,
+    stride_ob, stride_on, stride_oh, stride_od,
+    scale, H_OUT,
+    WINDOW: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_KV: tl.constexpr,
+):
+    """Differential SWA for one output head, one query block.
+
+    grid = (ceil(N / BLOCK_N), H_OUT, B)
+    Out[b, n, h, :] = softmax(Qh Kh^T)Vh - softmax(Qh' Kh'^T)Vh'  where h' = h + H_OUT
+    """
+    block_n = tl.program_id(0)
+    h = tl.program_id(1)
+    b = tl.program_id(2)
+
+    q_start = block_n * BLOCK_N
+    q_offs = tl.arange(0, BLOCK_N)
+    q_pos = q_start + q_offs
+    q_mask = q_pos < N
+
+    # K/V window spans [q_start - WINDOW, q_start + BLOCK_N + WINDOW)
+    kv_start = q_start - WINDOW
+    kv_offs = tl.arange(0, BLOCK_KV)
+    kv_pos = kv_start + kv_offs
+    kv_mask = (kv_pos >= 0) & (kv_pos < N)
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_ok = d_offs[None, :] < BLOCK_D
+
+    # SWA mask is purely relative, so it is shared by both heads. kv_start is offset by
+    # -WINDOW, hence |q_offs + WINDOW - kv_offs| <= WINDOW.
+    rel = q_offs[:, None] + WINDOW - kv_offs[None, :]
+    valid = (rel >= -WINDOW) & (rel <= WINDOW) & kv_mask[None, :] & q_mask[:, None]
+
+    acc = tl.zeros((BLOCK_N, BLOCK_D), dtype=tl.float32)
+
+    # head_sel 0 -> primary head h, 1 -> diff head h + H_OUT.
+    #
+    # tl.static_range, NOT a dynamic range(2). Measured: unrolled needs 64 KB of shared
+    # memory (both heads' tiles live) and emits 512 mma; a dynamic loop is WORSE, not
+    # better — Triton's pipeliner allocates multi-stage buffers for it and shared memory
+    # jumps to 160 KB, with mma halved to 256. 64 KB exceeds the 48 KB *static* limit
+    # and needs a cudaFuncSetAttribute opt-in from whoever launches it, which is the
+    # open question for the TRT AOT path (see AOT_KERNEL_STATUS.md).
+    for head_sel in tl.static_range(2):
+        hh = h + head_sel * H_OUT
+
+        q_ptrs = (Q + b * stride_qb + q_pos[:, None] * stride_qn
+                  + hh * stride_qh + d_offs[None, :] * stride_qd)
+        q = tl.load(q_ptrs, mask=q_mask[:, None] & d_ok, other=0.0)
+
+        k_ptrs = (K + b * stride_kb + kv_pos[:, None] * stride_kn
+                  + hh * stride_kh + d_offs[None, :] * stride_kd)
+        k = tl.load(k_ptrs, mask=kv_mask[:, None] & d_ok, other=0.0)
+
+        scores = tl.dot(q, tl.trans(k)) * scale          # tensor cores
+        scores = tl.where(valid, scores, float("-inf"))
+
+        row_max = tl.max(scores, axis=1)
+        e = tl.exp(scores - row_max[:, None])
+        e = tl.where(valid, e, 0.0)
+        row_sum = tl.sum(e, axis=1)
+        w = e / row_sum[:, None]
+
+        v_ptrs = (V + b * stride_vb + kv_pos[:, None] * stride_vn
+                  + hh * stride_vh + d_offs[None, :] * stride_vd)
+        v = tl.load(v_ptrs, mask=kv_mask[:, None] & d_ok, other=0.0)
+
+        out_h = tl.dot(w, v)                              # tensor cores
+
+        # FP32 accumulator: primary minus diff. The cancellation-sensitive step stays
+        # in FP32 even though the two products above are TF32.
+        acc += tl.where(head_sel == 0, out_h, -out_h)
+
+    o_ptrs = (Out + b * stride_ob + q_pos[:, None] * stride_on
+              + h * stride_oh + d_offs[None, :] * stride_od)
+    tl.store(o_ptrs, acc, mask=q_mask[:, None] & d_ok)
+
+
+# Launch geometry, kept here so the AOT path and the reference path agree exactly.
+#
+# BLOCK_KV MUST be >= BLOCK_N + 2*WINDOW or the K/V tile does not cover every position
+# the block's queries can attend to, and attention contributions are silently dropped.
+# (BLOCK_N=32 with BLOCK_KV=64 needs 66 and is therefore WRONG, even though it compiles
+# and fits in shared memory.)
+#
+# BLOCK_N=16 rather than 64, for two reasons measured on the real shapes:
+#   speed   0.306 ms/layer vs 0.432 at BLOCK_N=64 (JIT reference: 0.421). With a window
+#           of only +/-17, a 128-wide K/V tile is mostly masked-out waste; a 64-wide tile
+#           keeps the useful fraction high.
+#   memory  40 KB of shared memory vs 64 KB. 64 KB exceeds the 48 KB static limit and
+#           needs a cudaFuncSetAttribute opt-in that the TRT AOT launcher does not do —
+#           the BLOCK_N=64 engine built fine and then failed at enqueue with
+#           "Failed to enqueue status -1", returning zeros.
+WINDOW = 17
+BLOCK_N = 16
+BLOCK_D = 64
+BLOCK_KV = 64           # >= BLOCK_N + 2 * WINDOW = 50
+
+
+def diff_swa_mma(q, k, v, window: int = WINDOW):
+    """Reference launcher. q, k, v: (B, N, 2H, D) fp32 -> (B, N, H, D) fp32.
+
+    Used to validate the kernel before it is compiled AOT; the shipped path drives the
+    same kernel through trtp.aot_impl instead.
+    """
+    B, Nn, H2, D = q.shape
+    assert H2 % 2 == 0, f"expected an even head count, got {H2}"
+    assert D == BLOCK_D, f"kernel is specialised for D={BLOCK_D}, got {D}"
+    H = H2 // 2
+    out = torch.empty((B, Nn, H, D), device=q.device, dtype=torch.float32)
+    grid = (triton.cdiv(Nn, BLOCK_N), H, B)
+    diff_swa_mma_kernel[grid](
+        q, k, v, Nn, out,
+        *q.stride(), *k.stride(), *v.stride(), *out.stride(),
+        D ** -0.5, H,
+        WINDOW=window, BLOCK_N=BLOCK_N, BLOCK_D=BLOCK_D, BLOCK_KV=BLOCK_KV,
+    )
+    return out


### PR DESCRIPTION
Follow-up to #83. That PR made the SAME-L SWA plugin AOT-capable so its engine could go
inside the CUDA graph, but the AOT kernel it shipped was hand-written scalar FP32 — one
warp per query, no K/V reuse, zero `mma` instructions — so it was chosen only on sm_120
and JIT was kept everywhere else.

This replaces that kernel with a block-tiled one and removes the arch conditional.

## The kernel

`scripts/triton_diff_swa_mma.py` — BLOCK_N=16 queries per block share a 64-wide K/V tile in
shared memory; both attention products go through `tl.dot`, which lowers to
512 × `mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32`. `scripts/swa_mma_aot.py`
compiles it with `triton.compile()` and hands the PTX to `trtp.aot_impl`.

Triton generates the code rather than us hand-writing `mma` fragment layouts, but the
result is a plain PTX blob inside the engine — nothing re-enters Python at inference.

The one structural difference from `triton_swa_v2`: that kernel emits all 2H heads and
leaves the differential subtraction to a PyTorch caller. `aot_impl` returns a *single*
kernel, so there is no caller — each block owns one output head, processes input heads
`h` and `h + H`, and subtracts in the FP32 accumulator. That also avoids materialising a
2H-head intermediate.

TF32 in the two attention products is what the JIT path already did; the
cancellation-sensitive subtraction stays FP32.

## Measured — SAME-L decode, ms, median of 7 on idle GPUs

| sm_120 · RTX PRO 4500 | L=256 | L=1024 | L=1292 | L=2048 | L=4096 |
|---|---|---|---|---|---|
| JIT *(not capturable here)* | 55.1 | 227.2 | 289.1 | 457.7 | 920.2 |
| AOT hand-PTX (#83) | 62.5 | 251.2 | 318.7 | 502.8 | 1008.8 |
| **AOT MMA (this PR)** | 55.4 | **223.6** | **283.7** | **448.4** | **899.3** |

| sm_90 · H200 | L=256 | L=1024 | L=1292 | L=2048 | L=4096 |
|---|---|---|---|---|---|
| JIT | 12.4 | 47.0 | 61.1 | 98.5 | 194.4 |
| AOT hand-PTX (#83) | 12.7 | 47.3 | 60.7 | 96.6 | 195.5 |
| **AOT MMA (this PR)** | 12.4 | 48.4 | 62.6 | 100.0 | 196.8 |

PSNR vs the FP32 decoder at L=1292 on sm_120: MMA **51.45 dB**, JIT 51.43, hand-PTX 51.11.
Engine size +0.1%. Python/Triton callbacks per decode: 12 → 0.

**Correcting #83's benchmark table:** it claimed AOT was 24% slower on sm_90. That came
from CUDA events recorded on the default stream while the work ran on the runner's private
stream. Measured on the correct stream, hand-PTX AOT was already at parity on sm_90 (60.7
vs 61.1 at L=1292); the real penalty was sm_120 (+9.6%), which this PR removes.

## Also in here

- `SA3_SWA_PLUGIN=aot|jit` and `SA3_SWA_AOT=mma|ptx` build-time switches. Previously AOT
  was hardcoded per-arch with no escape hatch for a target where the kernel will not build.
- "Choosing the SAME-L attention kernel" in `build/README.md`, plus shorter notes in
  `README.md` and the `build.py` menu labels.
- The hand-written scalar kernel stays as `SA3_SWA_AOT=ptx`.

## Why the docs are emphatic about the failure mode

A JIT engine on sm_120 is not stream-capturable: `enqueueV3` returns `False` and the decode
stage is **silently omitted** from the mega-graph. The decoder then returns the pre-capture
warm-up decode of zero latents — a constant wash, byte-identical across seeds and prompts,
exit code 0. I confirmed this on the engine currently published on HuggingFace, not just
locally. The diagnostic is "render two seeds and compare bytes", which nobody would think
to do unprompted, so it is written down in all three places.

Three gotchas are recorded in `build/README.md` because each produces wrong output rather
than a build failure: TRT's AOT launcher passes inputs → extras → **outputs last** (getting
this wrong made the kernel dereference a sequence length as an address);
`BLOCK_KV >= BLOCK_N + 2*WINDOW` or attention contributions are silently dropped; and >48 KB
shared memory builds fine then fails at enqueue with "Failed to enqueue status -1".

## Validation

- sm_120 encoder + decoder: capture=True, replay writes output, cos(replay, eager) = 1.0000000
- sm_90 encoder + decoder on H200: same, cos = 1.0000000 / 1.0000001
- End-to-end sm_120, 30 s render via the mega-graph path: 95–97× realtime, two seeds give
  different output
- Op-level vs the JIT kernel: cos 0.9999986
- **Backwards compatibility:** the published sm_90 JIT engine produces byte-identical output
  under the old JIT-only code and this branch (md5 `fd4bbc2c...`), so registering `aot_impl`
  alongside `impl` does not disturb JIT dispatch. An AOT engine never imports Triton at
  inference; a JIT engine does.

Only the **sm_120** SAME-L engines are being republished on HuggingFace. sm_90 keeps its
JIT engines — they capture correctly on Hopper and AOT is no faster there — so the published
set is mixed, which `build/README.md` states outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)