### PR TITLE
optimized/mlx: add the output limiter to the MLX decode path

### DIFF
--- a/optimized/mlx/models/defs/limiter_mlx.py
+++ b/optimized/mlx/models/defs/limiter_mlx.py
@@ -1,0 +1,111 @@
+"""Output limiter in MLX — the shipped SA3 limiter (`dsp.limit_ship`) for the Apple-Silicon backend.
+
+Same setting as the TensorRT graft and the TFLite baked limiter: **sample-peak detector, ceiling
+0.977 (-0.2021 dBFS), 5.8 ms window** (LIMITER_SPEC.md §1). Applied to the decoder's float audio
+output on-device (before the int16 conversion), so the MLX backend emits already-limited audio.
+
+Algorithm (§2, factor=1): channel-linked sample-peak envelope -> block MAX decimate by D=64 ->
+required gain min(1, ceiling/env) -> running MIN over 2*Ld+1=9 taps (the brickwall) -> Hann smooth
+-> half-pixel linear upsample -> multiply. At factor=1 there is no polyphase conv — only abs/max/
+reshape/min/gather, all native MLX ops.
+
+⚠ NOT run on the repo's CI box (MLX needs Apple Silicon / Metal). The `limit_numpy` twin below uses
+the identical op sequence and is verified against `dsp.limit_ship` to max|Δ|=3.0e-7 across lengths;
+the MLX ops mirror it 1:1, so it should match on-device — but run `limit_numpy`-vs-`limit_mlx` and an
+ear check on a Mac before trusting it end to end.
+"""
+import math
+import numpy as np
+
+CEILING = 0.977      # -0.2021 dBFS sample-peak ceiling
+D = 64               # gain decimation
+LD = 4               # ceil(5.0ms * 44100 / D) -> 5.80 ms half-window
+
+
+def _hann(n):
+    w = np.hanning(n).astype(np.float32)
+    return w / w.sum()
+
+
+def _upsample_index(T, Tb):
+    """Half-pixel linear-upsample indices/weights (== F.interpolate align_corners=False)."""
+    src = (np.arange(T, dtype=np.float32) + 0.5) / D - 0.5
+    i0 = np.clip(np.floor(src), 0, Tb - 1).astype(np.int32)
+    frac = np.clip(src - i0, 0.0, 1.0).astype(np.float32)
+    i1 = np.minimum(i0 + 1, Tb - 1).astype(np.int32)
+    return i0, i1, frac
+
+
+def limit_mlx(x, ceiling=CEILING):
+    """x: mx.array (2, T) float32. Returns (2, T) with |y| <= ceiling. ceiling=inf bypasses exactly."""
+    import mlx.core as mx
+    if not math.isfinite(ceiling) or ceiling > 1e6:
+        return x
+    C, T = x.shape
+    Tb = (T + D - 1) // D
+    env = mx.max(mx.abs(x), axis=0)                                       # (T,) channel-linked sample peak
+    pad = Tb * D - T
+    if pad:
+        env = mx.concatenate([env, mx.repeat(env[-1:], pad)])            # replicate pad to a whole block
+    envd = mx.max(env.reshape(Tb, D), axis=1)                            # (Tb,) block MAX
+    g = mx.minimum(ceiling / mx.maximum(envd, 1e-12), 1.0)
+    gp = mx.concatenate([mx.ones((LD,), g.dtype), g, mx.ones((LD,), g.dtype)])   # running MIN, pad gain 1.0
+    gmin = gp[LD:LD + Tb]
+    for s in range(1, LD + 1):
+        gmin = mx.minimum(gmin, mx.minimum(gp[LD - s:LD - s + Tb], gp[LD + s:LD + s + Tb]))
+    hw = _hann(2 * LD + 1)                                               # Hann smooth as shifted weighted sum
+    gpad = mx.concatenate([mx.repeat(gmin[:1], LD), gmin, mx.repeat(gmin[-1:], LD)])
+    gs = mx.zeros((Tb,), g.dtype)
+    for j in range(2 * LD + 1):
+        gs = gs + float(hw[j]) * gpad[j:j + Tb]
+    i0, i1, frac = _upsample_index(T, Tb)                                # half-pixel linear upsample (gather + lerp)
+    gu = mx.take(gs, mx.array(i0)) * (1.0 - mx.array(frac)) + mx.take(gs, mx.array(i1)) * mx.array(frac)
+    return x * mx.minimum(gu, 1.0)[None, :]
+
+
+def limit_numpy(x, ceiling=CEILING):
+    """Pure-numpy twin — host fallback and the tested reference (verified vs dsp.limit_ship to 3e-7)."""
+    if not math.isfinite(ceiling) or ceiling > 1e6:
+        return x.astype(np.float32)
+    x = np.asarray(x, np.float32)
+    C, T = x.shape
+    Tb = (T + D - 1) // D
+    env = np.abs(x).max(0)
+    pad = Tb * D - T
+    if pad:
+        env = np.concatenate([env, np.repeat(env[-1:], pad)])
+    envd = env.reshape(Tb, D).max(1)
+    g = np.minimum(ceiling / np.maximum(envd, 1e-12), 1.0)
+    gp = np.concatenate([np.ones(LD, np.float32), g, np.ones(LD, np.float32)])
+    gmin = gp[LD:LD + Tb].copy()
+    for s in range(1, LD + 1):
+        gmin = np.minimum(gmin, np.minimum(gp[LD - s:LD - s + Tb], gp[LD + s:LD + s + Tb]))
+    hw = _hann(2 * LD + 1)
+    gpad = np.concatenate([np.repeat(gmin[:1], LD), gmin, np.repeat(gmin[-1:], LD)])
+    gs = np.zeros(Tb, np.float32)
+    for j in range(2 * LD + 1):
+        gs = gs + float(hw[j]) * gpad[j:j + Tb]
+    i0, i1, frac = _upsample_index(T, Tb)
+    gu = gs[i0] * (1.0 - frac) + gs[i1] * frac
+    return (x * np.minimum(gu, 1.0)).astype(np.float32)
+
+
+if __name__ == "__main__":
+    # Run on a Mac: checks limit_mlx == limit_numpy (the reference verified vs dsp.limit_ship to 3e-7),
+    # that the ceiling holds, and prints on-device timing. `python models/defs/limiter_mlx.py`
+    import time
+    try:
+        import mlx.core as mx
+    except Exception as e:  # pragma: no cover
+        raise SystemExit(f"MLX unavailable ({e}) — this self-check needs Apple Silicon.")
+    rng = np.random.RandomState(0)
+    worst = 0.0
+    for T in (4096 * 8, 4096 * 128, 4096 * 323):
+        x = (rng.standard_normal((2, T)) * 1.6).astype(np.float32)
+        ref = limit_numpy(x)
+        y = np.array(limit_mlx(mx.array(x)).astype(mx.float32))
+        d = float(np.abs(y - ref).max()); worst = max(worst, d)
+        t0 = time.time(); _ = np.array(limit_mlx(mx.array(x)).astype(mx.float32)); dt = (time.time() - t0) * 1e3
+        print(f"  T={T:7d}  peak={np.abs(y).max():.4f}  |mlx-numpy|={d:.3e}  {dt:.2f} ms")
+    print(f"PARITY {'OK' if worst < 1e-4 else 'DIFF %.2e' % worst}  (ceiling {CEILING})")
+

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -58,6 +58,7 @@ from models.defs.sa3_pipeline import (  # noqa: E402
     apply_prompt_padding, build_pingpong_schedule, sample_flow_pingpong,
     patched_decode, load_conditioner_from_npz,
 )
+from models.defs.limiter_mlx import limit_mlx  # noqa: E402
 from models.defs.lora_merge import (  # noqa: E402
     prepare_loras, apply_conditioner_lora, LoraError,
 )
@@ -458,6 +459,7 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
 
     # 5. Unpatch + trim
     audio = patched_decode(patches, patch_size=256, channels=2)
+    audio = limit_mlx(audio[0])[None]                                      # output limiter (ceiling 0.977), on-device
     mx.eval(audio)
     audio_np = np.array(audio.astype(mx.float32))[0]
     requested = int(round(seconds * SAMPLE_RATE))
@@ -903,7 +905,7 @@ def build_ui(initial_dit: str, initial_decoder: str, *, share: bool,
         if not np.isfinite(audio_np).all():
             return None, "error: model produced non-finite audio (try a higher σmax or different seed)"
 
-        pcm = (np.clip(audio_np, -1, 1) * 32767.0).astype(np.int16).T   # (T, 2)
+        pcm = np.rint(np.clip(audio_np, -1, 1) * 32767.0).astype(np.int16).T   # (T, 2); round-to-nearest (matches TRT/TFLite)
         basename = verbose_basename(prompt, negative_prompt, cfg, sigma_max, seed)
         out_path = OUTPUT_DIR / f"{basename}.wav"
         _save_wav(pcm, out_path)

--- a/optimized/mlx/scripts/sa3_mlx.py
+++ b/optimized/mlx/scripts/sa3_mlx.py
@@ -30,6 +30,7 @@ from models.defs.sa3_pipeline import (
     load_conditioner_from_npz,
 )
 from models.defs.t5gemma_mlx import T5Gemma
+from models.defs.limiter_mlx import limit_mlx
 from weights import ensure_local, is_present
 
 SAMPLE_RATE = 44100
@@ -234,7 +235,7 @@ def save_wav(path: str, audio: np.ndarray, sample_rate: int = SAMPLE_RATE):
         n_bad = int((~np.isfinite(audio)).sum())
         raise RuntimeError(f"refusing to write WAV — audio contains {n_bad} non-finite samples (NaN/Inf)")
     audio = np.clip(audio, -1.0, 1.0)
-    pcm = (audio * 32767.0).astype(np.int16).T  # (T, channels) interleaved
+    pcm = np.rint(audio * 32767.0).astype(np.int16).T  # (T, channels) interleaved; round-to-nearest (matches TRT/TFLite)
     with wave.open(path, "wb") as w:
         w.setnchannels(audio.shape[0])
         w.setsampwidth(2)
@@ -834,6 +835,7 @@ def main():
     # ── 5. Unpatch → audio + save WAV ──
     t0 = time.time()
     audio = patched_decode(patches, patch_size=256, channels=2)            # (1, 2, T_lat*4096)
+    audio = limit_mlx(audio[0])[None]                                      # output limiter (ceiling 0.977), on-device before int16
     mx.eval(audio)
     audio_np = np.array(audio.astype(mx.float32))[0]                       # (2, T_lat*4096)
     requested_samples = int(round(args.seconds * SAMPLE_RATE))


### PR DESCRIPTION
## optimized/mlx: add the output limiter to the MLX decode path

Adds the shipped SA3 output limiter (`dsp.limit_ship` — sample-peak, ceiling **0.977** / −0.2021 dBFS, 5.8 ms window) to the MLX / Apple-Silicon backend, matching the TensorRT graft and the TFLite baked limiter. Applied **on-device** to the decoder's float audio (before the int16 conversion) in both the CLI and gradio, so the MLX backend emits already-limited audio (t2a / a2a / inpaint).

### ⚠ Needs a Mac before merge
MLX can't run on the x86/CUDA box I built this on, so `limit_mlx` was **not executed** — only its numpy twin. Please verify on Apple Silicon:
```
cd optimized/mlx && python models/defs/limiter_mlx.py
```
This self-check prints **`limit_mlx` vs `limit_numpy` parity** (should be < 1e-4), the delivered **ceiling** (0.977), and on-device **timing**. Then an ear check on a real render. **Please don't merge until that passes.**

### How
- **`models/defs/limiter_mlx.py`** — `limit_mlx` (MLX ops only: abs / max / reshape-max / shifted-min / Hann-sum / gather-lerp — no polyphase conv at factor=1) + a `limit_numpy` twin. The linear upsample is half-pixel, matching `F.interpolate(align_corners=False)` / the TFLite `RESIZE_BILINEAR`.
- **`sa3_mlx.py` + `sa3_gradio.py`** — apply `limit_mlx` right after `patched_decode`; the int16 delivery cast now **rounds** (`np.rint`) instead of truncating, matching TRT/TFLite. Output stays float32 (matches the existing MLX IO).

### Verification so far (without a Mac)
The `limit_numpy` twin (identical op sequence to `limit_mlx`) matches `dsp.limit_ship` to **max|Δ| = 3.0e-7** across lengths with the ceiling held; the MLX ops mirror it 1:1, so it should match on-device — but that's what the Mac self-check confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
