### PR TITLE
lora: let callers and the gradio Layer filter exclude conditioner adapters

### DIFF
--- a/stable_audio_3/interface/diffusion_cond.py
+++ b/stable_audio_3/interface/diffusion_cond.py
@@ -104,7 +104,7 @@ def generate_cond(
         preview_every = None
 
     # Parse per-LoRA controls from trailing args
-    # Each LoRA has 5 controls: strength, interval_min, interval_max, layer_filter
+    # Each LoRA has 4 controls: strength, interval_min, interval_max, layer_filter
     lora_configs = None
     if n_loras > 0 and len(lora_args) >= n_loras * 4:
         lora_configs = []

--- a/stable_audio_3/interface/diffusion_cond.py
+++ b/stable_audio_3/interface/diffusion_cond.py
@@ -12,7 +12,7 @@ from einops import rearrange
 
 from stable_audio_3.interface.aeiou import audio_spectrogram_image
 from stable_audio_3.inference.distribution_shift import LogSNRShift, FluxDistributionShift, DistributionShift, IdentityDistributionShift
-from stable_audio_3.models.lora import has_lora
+from stable_audio_3.models.lora import has_lora, filter_lora_layers
 from stable_audio_3.interface.reprompt import reprompt as _reprompt_fn, get_model as _reprompt_get_model, is_model_cached as _reprompt_is_model_cached
 
 stable_audio_3_model = None
@@ -115,6 +115,19 @@ def generate_cond(
             interval_max = lora_args[off + 2]
             layer_filter = lora_args[off + 3]
             stable_audio_3_model.set_lora_strength(strength, lora_index=i)
+            # The DiT applies layer_filter itself, inside its forward, so it only
+            # ever sees adapters in the transformer. Conditioner adapters are
+            # unreachable from there — for SA3 that is the duration embedder
+            # (conditioners.seconds_total.embedder.embedding.1), the one non-DiT
+            # target LoRA training produces — so typing its name in the box did
+            # nothing. Apply the same filter here to cover it.
+            #
+            # Once per generate is enough: unlike the DiT, which re-filters every
+            # sampling step, nothing re-enables conditioner adapters mid-run. An
+            # empty filter re-enables them, which is the intended default.
+            conditioner = getattr(stable_audio_3_model.model, "conditioner", None)
+            if conditioner is not None:
+                filter_lora_layers(conditioner, layer_filter, lora_index=i)
             lora_configs.append({
                 "lora_index": i,
                 "interval": (interval_min, interval_max),
@@ -360,7 +373,12 @@ def create_sampling_ui(stable_audio_3_model, default_prompt=None):
                         with gr.Row():
                             int_min = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, value=0.0, label="Interval min")
                             int_max = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, value=1.0, label="Interval max")
-                            lyr_filt = gr.Textbox(label="Layer filter", placeholder="")
+                            lyr_filt = gr.Textbox(
+                                label="Layer filter",
+                                placeholder="seconds_total, .transformer.layers",
+                                info="Comma-separated substrings to disable. "
+                                     "Covers conditioner layers too.",
+                            )
                         lora_ui_inputs.extend([strength, int_min, int_max, lyr_filt])
 
             with gr.Accordion("Sampler params", open=False):

--- a/stable_audio_3/models/lora/loader.py
+++ b/stable_audio_3/models/lora/loader.py
@@ -16,7 +16,24 @@ from .utils import (
 from ...verbose import vprint
 
 
-def load_and_apply_loras(model, lora_ckpt_paths, model_type, svd_bases_path=None):
+def _merge_exclude(ckpt_exclude, extra_exclude):
+    """Union of a checkpoint's saved exclude list and a caller-supplied one.
+
+    Order-preserving and de-duplicated. Returns None when both are empty, since
+    add_lora treats None as "no filtering" and takes a faster path than an empty
+    list would suggest.
+    """
+    if not extra_exclude:
+        return ckpt_exclude
+    merged = list(ckpt_exclude or [])
+    for pat in extra_exclude:
+        if pat not in merged:
+            merged.append(pat)
+    return merged or None
+
+
+def load_and_apply_loras(model, lora_ckpt_paths, model_type, svd_bases_path=None,
+                         exclude=None):
     """Load LoRA checkpoints from disk and attach them to `model`.
 
     - Uses a two-pass approach: first resolves each LoRA's adapter type, then
@@ -35,6 +52,13 @@ def load_and_apply_loras(model, lora_ckpt_paths, model_type, svd_bases_path=None
         model_type: String from the model config, e.g. "diffusion_cond".
         svd_bases_path: Optional path to a precomputed SVD bases .pt file
             (used only by -XS adapter types).
+        exclude: Optional list of substrings to exclude *in addition to* each
+            checkpoint's own saved exclude list. Additive by design: it can only
+            ever skip more layers, never resurrect one the training run
+            deliberately left out. Useful for adapters trained before a pattern
+            was added to the defaults — e.g. the SA3 conditioner's
+            `seconds_total` duration embedder, which older LoRAs adapt because
+            it matched none of the historical exclude patterns.
 
     Returns:
         List of display names (file stems) in the same order as the input paths.
@@ -77,7 +101,11 @@ def load_and_apply_loras(model, lora_ckpt_paths, model_type, svd_bases_path=None
         rank = config_dict.get("rank", infer_global_rank(state_dict))
         alpha = config_dict.get("alpha", rank)
         include = config_dict.get("include", None)
-        exclude = config_dict.get("exclude", None)
+        ckpt_exclude = config_dict.get("exclude", None)
+        lora_exclude = _merge_exclude(ckpt_exclude, exclude)
+        if lora_exclude != ckpt_exclude:
+            added = [p for p in lora_exclude if p not in (ckpt_exclude or [])]
+            print(f"  excluding additionally: {added}")
         is_xs = adapter_type.endswith("-xs")
 
         lora_config = {
@@ -89,12 +117,12 @@ def load_and_apply_loras(model, lora_ckpt_paths, model_type, svd_bases_path=None
             },
         }
         if is_cond:
-            add_lora(model.model, lora_config, include=include, exclude=exclude,
+            add_lora(model.model, lora_config, include=include, exclude=lora_exclude,
                      svd_bases=model_svd_bases if is_xs else None)
-            add_lora(model.conditioner, lora_config, include=include, exclude=exclude,
+            add_lora(model.conditioner, lora_config, include=include, exclude=lora_exclude,
                      svd_bases=cond_svd_bases if is_xs else None)
         else:
-            add_lora(model, lora_config, include=include, exclude=exclude,
+            add_lora(model, lora_config, include=include, exclude=lora_exclude,
                      svd_bases=model_svd_bases if is_xs else None)
 
         prepare_dora_state_dict(state_dict)


### PR DESCRIPTION
## Problem

Two ways to skip a LoRA layer, and neither could reach adapters outside the DiT.

**1. At load time**, `load_and_apply_loras` honours the `include`/`exclude` lists saved in each checkpoint's metadata, but a caller has no way to skip a layer the training run did not. Already-trained adapters are therefore unfixable at inference: if a pattern was missing from the defaults when they were trained, every load faithfully rebuilds that adapter.

**2. In the gradio UI**, `filter_lora_layers` is called from `DiffusionTransformer.forward`, so `self` is the DiT. Adapters on `model.conditioner` — a sibling of `model.model` — are unreachable, so typing their layer name in the "Layer filter" box silently does nothing. Misleading, since the control presents itself as a whole-model filter.

Concretely, for SA3 the affected layer is the duration embedder:

```
conditioners.seconds_total.embedder.embedding.1
```

a `Linear(256, 768)` and the **only** adapter target outside the DiT. It matched none of the historical exclude patterns, so LoRAs trained with default settings all carry an adapter on it — and it was the one layer neither mechanism could switch off.

## Changes

**`loader.py`** — an `exclude` parameter, unioned with each checkpoint's own list rather than replacing it. Additive by design: it can only skip more layers, never resurrect one the training run deliberately left out, so it is safe to pass blindly. `include` is deliberately *not* exposed, since unioning includes would widen the match set and could re-enable excluded layers.

**`interface/diffusion_cond.py`** — the same user-supplied `layer_filter` is applied to the conditioner in `generate()`. Once per generate is sufficient: unlike the DiT, which re-filters every sampling step inside `forward`, nothing re-enables conditioner adapters mid-run. An empty filter re-enables them, which is the intended default.

## Verification

Loader, against a rank-16 adapter whose metadata excludes nine patterns but not `seconds_total`:

```
no runtime exclude          conditioner adapters=[seconds_total...]  DiT=168
exclude=['seconds_total']   conditioner adapters=[]                 DiT=168
```

`_merge_exclude` is unit-checked for both-empty (returns `None` so `add_lora` keeps its unfiltered fast path), either side empty, and union with order preserved and duplicates dropped.

UI, `‖W − W0‖ / ‖W0‖` for the conditioner layer against what the user types:

| typed | effect |
|---|---|
| `''` | 4.1628% — active, default |
| `seconds_total` | **0.0000%** — exactly base |
| `SECONDS_TOTAL` | 0.0000% — filters are lowercased |
| `.transformer.layers` | 4.1628% — no match, correctly untouched |
| `seconds_total, .ff.` | 0.0000% — comma-separated OR |

DiT adapter count stays 168 throughout.

## Notes

- **No new UI control and no change to the per-LoRA argument count**, so callers passing four controls per LoRA keep working.
- The textbox gains a placeholder and info line stating that it covers conditioner layers.
- One asymmetry, deliberate: the DiT re-applies the filter every sampling step and so participates in the sigma-interval gating, while the conditioner is set once per generate. That is correct — conditioning is computed once, not per-sigma — but it means a conditioner adapter is not interval-gated the way DiT adapters are.