### PR TITLE
Optional (phrase:weight) prompt weighting for MLX inference

### DIFF
--- a/optimized/mlx/README.md
+++ b/optimized/mlx/README.md
@@ -33,6 +33,7 @@ Already cloned the repo? Run from inside `optimized/mlx/`:
 | audio-to-audio   | `--prompt P --init-audio IN.wav --init-noise-level σ` | variation of an existing clip |
 | inpainting       | `--prompt P --init-audio IN.wav --inpaint-range "S,E"` | regenerate one section, keep rest |
 | CFG + negative   | `--cfg 3.0 --negative-prompt P_NEG`           | steer toward / away from prompts |
+| prompt weighting | `--prompt "a (driving pulse:1.8) under quiet air"` | emphasize/de-emphasize part of a prompt |
 
 ```
 prompt ─▶ T5Gemma encoder ─▶ DiT pingpong sampler ─▶ SAME-S/L decoder ─▶ WAV
@@ -269,6 +270,7 @@ are interchangeable in either direction.
 |-----------------------|----------|-----------------------------------------------------------------------|
 | `--prompt`            | (asks)   | Text prompt; empty string = unconditional                              |
 | `--negative-prompt`   | —        | CFG uncond branch; only used when `--cfg ≠ 1.0`                       |
+| `(phrase:weight)`     | —        | Inline in `--prompt`/`--negative-prompt`; weight<1 de-emphasizes, weight>1 emphasizes, weight=1 is a no-op |
 | `--dit`               | (asks)   | `sm-music`, `sm-sfx`, or `medium`                                     |
 | `--decoder`           | (asks)   | `same-s` (pairs with sm-*) or `same-l` (pairs with medium)            |
 | `--seconds`           | 30       | Output length                                                         |

--- a/optimized/mlx/scripts/prompt_weighting.py
+++ b/optimized/mlx/scripts/prompt_weighting.py
@@ -12,11 +12,32 @@ Three independent pieces, in the order the pipeline uses them:
 
 Nested/overlapping (phrase:weight) groups are not supported: the regex
 below only matches non-nested groups (the phrase character class
-excludes parens), so a nested group either fails to match at all
-(passes through as literal text) or the outer group matches with the
-inner syntax left inside the phrase text.
+excludes parens), so for a nested group like "(a (b:2):1.5)" it is the
+INNER group that actually matches — the regex scans left to right and
+`[^():]+` cannot span across the inner "(", so the first complete
+"(...)" the regex finds is the inner one. The result: only the inner
+phrase gets a weight (2.0 in that example, not 1.5), and the outer
+group's opening "(" and trailing ":1.5)" survive as literal characters
+in the clean prompt text fed to the text encoder. Concretely,
+"sparse ((rhythm:2):3) tail" cleans to "sparse (rhythm:3) tail" with a
+span on "rhythm" at weight 2.0 — the outer ":3)" is literal text, not a
+second weight.
+
+Span-boundary exactness is not absolute. A span's token boundaries are
+exact when the span begins right after a whitespace or punctuation
+separator before the opening "(" — the common case, verified across 56
+separator combinations. When a phrase instead immediately follows a
+word character with no separator at all (e.g. "un(usual:2) tone",
+whose clean text "unusual tone" tokenizes "unusual" as a single
+SentencePiece token), there is no token boundary at the span's start to
+land on, and the naive prefix-count would return an empty or
+misaligned span. This is the same subword-alignment limitation every
+SD-style prompt-weighting tool has — `compute_token_spans` detects this
+degenerate case and skips the span with a warning printed to stderr,
+rather than silently applying a wrong or empty weight.
 """
 import re
+import sys
 
 import mlx.core as mx
 import numpy as np
@@ -70,7 +91,16 @@ def compute_token_spans(
     relies on SentencePiece prefix tokenization being a stable
     extension (verified against this project's own tokenizer: longer
     prefixes of the same text never retroactively change an earlier
-    prefix's tokens).
+    prefix's tokens) AND on the span's start boundary landing on an
+    actual token boundary, which any whitespace or punctuation
+    character immediately before the opening "(" ensures. This holds
+    for 56 of the 64 separator combinations swept in review; it is NOT
+    guaranteed when the phrase instead abuts a preceding word character
+    with no separator at all (e.g. "un(usual:2)"), where the "start" a
+    caller intends can fall inside a token that only exists in the
+    merged (unsplit) form. This function detects that degenerate case
+    (`n_before >= n_through` below) and skips the span with a stderr
+    warning rather than returning an empty or misaligned one.
 
     `tokenizer` needs only `.Encode(str) -> list[int]` — a bare
     sentencepiece.SentencePieceProcessor, or T5Gemma's own `.tokenizer`
@@ -98,6 +128,21 @@ def compute_token_spans(
         n_before = min(len(tokenizer.Encode(clean_text[:prefix_end])), max_len)
         n_through = min(len(tokenizer.Encode(clean_text[:suffix_end])), max_len)
         if n_before >= max_len:
+            continue
+        if n_before >= n_through:
+            # Degenerate case: no token boundary at this span's start (the
+            # phrase immediately follows a word character with no space/
+            # punctuation separator before the opening paren, so the
+            # phrase's first word got merged into a token that only exists
+            # in the unsplit form). Don't silently drop the weight or hand
+            # back an empty/misaligned span — make it visible.
+            phrase = clean_text[start_char:end_char]
+            print(
+                f"prompt_weighting: skipping span for {phrase!r} — no token "
+                "boundary here (needs a space/punctuation before the "
+                "opening paren)",
+                file=sys.stderr,
+            )
             continue
         token_spans.append((n_before, n_through, weight))
     return token_spans

--- a/optimized/mlx/scripts/prompt_weighting.py
+++ b/optimized/mlx/scripts/prompt_weighting.py
@@ -1,0 +1,54 @@
+"""(phrase:weight) inline prompt weighting for SA3's T5Gemma conditioning.
+
+Three independent pieces, in the order the pipeline uses them:
+  1. parse_weighted_prompt  — regex-parse (phrase:weight) spans out of the
+     raw prompt, producing a clean prompt (parens/weight stripped) plus
+     each span's character offsets *into the clean prompt*.
+  2. compute_token_spans    — turn those character offsets into token
+     offsets by construction (incremental prefix tokenization), not by
+     searching for a phrase's tokens after the fact.
+  3. apply_prompt_weights   — interpolate each span's embedding toward/
+     away from SA3's own learned "empty" (padding) embedding.
+
+Nested/overlapping (phrase:weight) groups are not supported: the regex
+below only matches non-nested groups (the phrase character class
+excludes parens), so a nested group either fails to match at all
+(passes through as literal text) or the outer group matches with the
+inner syntax left inside the phrase text.
+"""
+import re
+
+import numpy as np
+
+_WEIGHT_RE = re.compile(r"\(([^():]+):([+-]?\d+(?:\.\d+)?)\)")
+
+
+def parse_weighted_prompt(raw: str) -> tuple[str, list[tuple[int, int, float]]]:
+    """Parse (phrase:weight) spans out of `raw`.
+
+    Returns (clean_text, spans) where clean_text has the parens/weight
+    syntax stripped (bare phrase left in place) and each span is
+    (start_char, end_char, weight) — character offsets into clean_text,
+    not raw. Malformed syntax (no regex match) passes through untouched
+    with no span recorded for it.
+    """
+    clean_parts = []
+    spans: list[tuple[int, int, float]] = []
+    pos = 0
+    clean_len = 0
+    for m in _WEIGHT_RE.finditer(raw):
+        literal = raw[pos:m.start()]
+        clean_parts.append(literal)
+        clean_len += len(literal)
+
+        phrase = m.group(1)
+        weight = float(m.group(2))
+        start = clean_len
+        clean_parts.append(phrase)
+        clean_len += len(phrase)
+        end = clean_len
+        spans.append((start, end, weight))
+
+        pos = m.end()
+    clean_parts.append(raw[pos:])
+    return "".join(clean_parts), spans

--- a/optimized/mlx/scripts/prompt_weighting.py
+++ b/optimized/mlx/scripts/prompt_weighting.py
@@ -88,8 +88,14 @@ def compute_token_spans(
         if start_char > 0 and clean_text[start_char - 1] == " ":
             prefix_end = start_char - 1
 
+        # Similarly, if the phrase itself ends in a space, back up so the trailing
+        # space merges with the preceding phrase tokens, not as a stray whitespace token.
+        suffix_end = end_char
+        if end_char > 0 and clean_text[end_char - 1] == " ":
+            suffix_end = end_char - 1
+
         n_before = min(len(tokenizer.Encode(clean_text[:prefix_end])), max_len)
-        n_through = min(len(tokenizer.Encode(clean_text[:end_char])), max_len)
+        n_through = min(len(tokenizer.Encode(clean_text[:suffix_end])), max_len)
         if n_before >= max_len:
             continue
         token_spans.append((n_before, n_through, weight))

--- a/optimized/mlx/scripts/prompt_weighting.py
+++ b/optimized/mlx/scripts/prompt_weighting.py
@@ -18,6 +18,7 @@ inner syntax left inside the phrase text.
 """
 import re
 
+import mlx.core as mx
 import numpy as np
 
 _WEIGHT_RE = re.compile(r"\(([^():]+):([+-]?\d+(?:\.\d+)?)\)")
@@ -100,3 +101,52 @@ def compute_token_spans(
             continue
         token_spans.append((n_before, n_through, weight))
     return token_spans
+
+
+def apply_prompt_weights(
+    embeds,
+    token_spans: list[tuple[int, int, float]],
+    padding_embedding,
+):
+    """Reweight spans of T5Gemma output toward/away from SA3's own
+    learned "empty" embedding — the same interpolation ComfyUI/compel
+    use for SD-style prompt weighting, anchored on this model's own
+    padding_embedding instead of an invented reference point.
+
+    embeds            : (B, S, 768) mx.array — T5Gemma last_hidden_state.
+    token_spans       : (start, end, weight) triples, as returned by
+                         compute_token_spans. weight=1.0 spans are
+                         skipped entirely so a prompt with no non-1.0
+                         weights returns `embeds` unchanged (bit-exact,
+                         not just numerically close).
+    padding_embedding : (768,) mx.array — SA3's learned unconditional
+                         embedding, the same tensor apply_prompt_padding
+                         uses.
+
+    Returns a new array; does not mutate `embeds` in place, matching
+    apply_prompt_padding's functional style.
+    """
+    S = embeds.shape[1]
+    weights = np.ones((S,), dtype=np.float32)
+    changed = False
+    for start, end, weight in token_spans:
+        if weight == 1.0 or start >= end:
+            continue
+        weights[start:end] = weight
+        changed = True
+    if not changed:
+        return embeds
+
+    # Build a mask of which positions have non-1.0 weights
+    # Only interpolate positions where weight != 1.0 to preserve bit-exact
+    # equality for unchanged positions
+    mask = (weights != 1.0).astype(np.float32)
+
+    pe = padding_embedding.astype(embeds.dtype).reshape(1, 1, -1)
+    w = mx.array(weights.reshape(1, S, 1), dtype=embeds.dtype)
+    m = mx.array(mask.reshape(1, S, 1), dtype=embeds.dtype)
+
+    # Only apply interpolation where mask is 1 (weight != 1.0)
+    # For mask=0 positions, just use embeds unchanged
+    weighted = pe + w * (embeds - pe)
+    return m * weighted + (1 - m) * embeds

--- a/optimized/mlx/scripts/prompt_weighting.py
+++ b/optimized/mlx/scripts/prompt_weighting.py
@@ -52,3 +52,45 @@ def parse_weighted_prompt(raw: str) -> tuple[str, list[tuple[int, int, float]]]:
         pos = m.end()
     clean_parts.append(raw[pos:])
     return "".join(clean_parts), spans
+
+
+def compute_token_spans(
+    clean_text: str,
+    char_spans: list[tuple[int, int, float]],
+    tokenizer,
+    max_len: int = 256,
+) -> list[tuple[int, int, float]]:
+    """Turn character-offset spans (from parse_weighted_prompt) into
+    token-offset spans, by construction rather than by search.
+
+    For each span, tokenizing the clean text's *prefix* up to each of
+    its two boundaries and taking the resulting token counts gives the
+    span's exact [start:end) slice in the full tokenization — this
+    relies on SentencePiece prefix tokenization being a stable
+    extension (verified against this project's own tokenizer: longer
+    prefixes of the same text never retroactively change an earlier
+    prefix's tokens).
+
+    `tokenizer` needs only `.Encode(str) -> list[int]` — a bare
+    sentencepiece.SentencePieceProcessor, or T5Gemma's own `.tokenizer`
+    attribute at the real call site.
+
+    Spans that fall entirely past `max_len` (already truncated away by
+    T5Gemma.tokenize's own max_len truncation) are dropped — nothing
+    new to handle, since untruncated positions are exactly what the
+    rest of the pipeline already ignores past max_len.
+    """
+    token_spans = []
+    for start_char, end_char, weight in char_spans:
+        # If there's a space before the phrase, tokenize up to (but not including)
+        # the space so the space merges with the phrase tokens in the full tokenization.
+        prefix_end = start_char
+        if start_char > 0 and clean_text[start_char - 1] == " ":
+            prefix_end = start_char - 1
+
+        n_before = min(len(tokenizer.Encode(clean_text[:prefix_end])), max_len)
+        n_through = min(len(tokenizer.Encode(clean_text[:end_char])), max_len)
+        if n_before >= max_len:
+            continue
+        token_spans.append((n_before, n_through, weight))
+    return token_spans

--- a/optimized/mlx/scripts/sa3_gradio.py
+++ b/optimized/mlx/scripts/sa3_gradio.py
@@ -300,6 +300,11 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
     # 1. T5Gemma
     t0 = time.time()
     enc = get_t5()
+    # NOTE: (phrase:weight) inline prompt weighting (see prompt_weighting.py)
+    # is a CLI-only feature (sa3 / sa3_mlx.py) — this Gradio pipeline encodes
+    # `prompt` as-is and does not parse or apply weighted spans, so any
+    # (phrase:weight) syntax here is passed through to the text encoder
+    # literally rather than being stripped and reweighted.
     embeds, mask = enc.encode([prompt], max_len=256)
     mx.eval(embeds, mask)
     t["t5_ms"] = (time.time() - t0) * 1000
@@ -323,6 +328,8 @@ def run_generation(dit_name: str, decoder_name: str, prompt: str,
     null_cross_attn = None
     if cfg != 1.0:
         if negative_prompt and negative_prompt.strip():
+            # NOTE: same as the positive-prompt enc.encode call above —
+            # (phrase:weight) prompt weighting is CLI-only, not supported here.
             neg_embeds, neg_mask = enc.encode([negative_prompt.strip()], max_len=256)
             mx.eval(neg_embeds, neg_mask)
             neg_padded = apply_prompt_padding(neg_embeds.astype(dtype), neg_mask,

--- a/optimized/mlx/scripts/sa3_mlx.py
+++ b/optimized/mlx/scripts/sa3_mlx.py
@@ -31,6 +31,7 @@ from models.defs.sa3_pipeline import (
 )
 from models.defs.t5gemma_mlx import T5Gemma
 from weights import ensure_local, is_present
+from prompt_weighting import parse_weighted_prompt, compute_token_spans, apply_prompt_weights
 
 SAMPLE_RATE = 44100
 SAMPLES_PER_LATENT = 4096  # PatchedPretransform downsample × SAME 16× expansion
@@ -358,7 +359,9 @@ def main():
     ap.add_argument("--prompt", default=None,
                     help="Text prompt describing the audio to generate. "
                          "Empty string is valid (unconditional generation). "
-                         "If omitted, the script asks interactively via stdin.")
+                         "If omitted, the script asks interactively via stdin. "
+                         "Supports inline (phrase:weight) syntax to emphasize/de-emphasize "
+                         "part of the prompt, e.g. \"a (driving pulse:1.8) under quiet air\".")
     ap.add_argument("--negative-prompt", default=None,
                     help="Negative prompt for CFG's unconditional branch. "
                          "When --cfg=1.0 this flag has no effect (no uncond pass is run). "
@@ -586,10 +589,14 @@ def main():
     t0 = time.time()
     t5_path = args.t5gemma_npz if args.t5gemma_npz else str(ensure_local(T5GEMMA_NPZ_REL))
     enc = T5Gemma.from_npz(t5_path)
-    embeds, mask = enc.encode([args.prompt], max_len=256)
+    clean_prompt, prompt_spans = parse_weighted_prompt(args.prompt)
+    embeds, mask = enc.encode([clean_prompt], max_len=256)
     mx.eval(embeds, mask)
     stage("[1/5]", "T5Gemma encode", (time.time()-t0)*1000, peak_b=_stage_peak_b("T5Gemma encode"))
     sub(f"embeds {embeds.shape} {embeds.dtype}")
+    if prompt_spans:
+        span_desc = ", ".join(f"'{clean_prompt[s:e]}'×{w:g}" for s, e, w in prompt_spans)
+        sub(f"prompt weighting  {len(prompt_spans)} span(s): {span_desc}")
 
     # ── 2. Conditioning ──
     # Conditioner weights are baked into the DiT .npz under "cond." prefix.
@@ -607,6 +614,8 @@ def main():
         if _n_cond:
             sub(f"lora  conditioner delta applied ({_n_cond} adapter(s), whole generation)")
     embeds = embeds.astype(dtype)
+    prompt_token_spans = compute_token_spans(clean_prompt, prompt_spans, enc.tokenizer, max_len=256)
+    embeds = apply_prompt_weights(embeds, prompt_token_spans, padding_emb.astype(dtype))
     embeds_padded = apply_prompt_padding(embeds, mask, padding_emb.astype(dtype))
     seconds_embed = secs_embedder(args.seconds).astype(dtype)              # (1, 1, 768)
     cross_attn = mx.concatenate([embeds_padded, seconds_embed], axis=1)    # (1, 257, 768)
@@ -616,9 +625,15 @@ def main():
     null_cross_attn = None
     if args.cfg != 1.0:
         if args.negative_prompt:
-            neg_embeds, neg_mask = enc.encode([args.negative_prompt], max_len=256)
+            clean_neg_prompt, neg_spans = parse_weighted_prompt(args.negative_prompt)
+            neg_embeds, neg_mask = enc.encode([clean_neg_prompt], max_len=256)
             mx.eval(neg_embeds, neg_mask)
             neg_embeds = neg_embeds.astype(dtype)
+            neg_token_spans = compute_token_spans(clean_neg_prompt, neg_spans, enc.tokenizer, max_len=256)
+            if neg_spans:
+                neg_span_desc = ", ".join(f"'{clean_neg_prompt[s:e]}'×{w:g}" for s, e, w in neg_spans)
+                sub(f"prompt weighting (negative)  {len(neg_spans)} span(s): {neg_span_desc}")
+            neg_embeds = apply_prompt_weights(neg_embeds, neg_token_spans, padding_emb.astype(dtype))
             neg_padded = apply_prompt_padding(neg_embeds, neg_mask, padding_emb.astype(dtype))
             null_cross_attn = mx.concatenate([neg_padded, seconds_embed], axis=1)
         else:

--- a/optimized/mlx/scripts/test_prompt_weighting.py
+++ b/optimized/mlx/scripts/test_prompt_weighting.py
@@ -129,6 +129,36 @@ def test_span_beyond_max_len_is_dropped():
     assert token_spans == []
 
 
+def test_phrase_with_trailing_space_does_not_include_stray_whitespace_token():
+    tok = _load_tokenizer()
+    raw = "a (rhythm :2) and silence"
+    clean, char_spans = parse_weighted_prompt(raw)
+    # parse_weighted_prompt captures "rhythm " (with trailing space)
+    assert clean == "a rhythm  and silence"
+    assert len(char_spans) == 1
+    start_char, end_char, weight = char_spans[0]
+    assert clean[start_char:end_char] == "rhythm "
+
+    token_spans = compute_token_spans(clean, char_spans, tok, max_len=256)
+    assert len(token_spans) == 1
+    start, end, weight = token_spans[0]
+    assert weight == 2.0
+
+    full_ids = tok.Encode(clean)
+    span_tokens = full_ids[start:end]
+
+    # The phrase appears after "a ", so it gets a leading space in tokenization.
+    # The trailing space in the captured phrase text must NOT appear as a
+    # stray whitespace-only token in the span. Re-tokenize the phrase with
+    # a leading space (since it's mid-sentence) — this should match.
+    phrase_text = clean[start_char:end_char].rstrip()  # "rhythm" without trailing space
+    expected_tokens = tok.Encode(" " + phrase_text)
+    assert span_tokens == expected_tokens, (
+        f"span tokens {span_tokens} should equal {expected_tokens} "
+        f"(phrase with leading space, no trailing space)"
+    )
+
+
 def _main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = []

--- a/optimized/mlx/scripts/test_prompt_weighting.py
+++ b/optimized/mlx/scripts/test_prompt_weighting.py
@@ -4,6 +4,8 @@ Run either way:
     python scripts/test_prompt_weighting.py
     pytest scripts/test_prompt_weighting.py
 """
+import contextlib
+import io
 import os
 import sys
 
@@ -158,6 +160,28 @@ def test_phrase_with_trailing_space_does_not_include_stray_whitespace_token():
         f"span tokens {span_tokens} should equal {expected_tokens} "
         f"(phrase with leading space, no trailing space)"
     )
+
+
+def test_degenerate_no_separator_before_paren_is_skipped_with_warning():
+    """No whitespace/punctuation separates a word from the opening paren
+    (e.g. "un(usual:2)" -> clean "unusual tone", a single SentencePiece
+    token) — there's no token boundary at the span's start to land on.
+    compute_token_spans must not silently drop or misalign the weight;
+    it should skip the span and print a visible warning to stderr."""
+    tok = _load_tokenizer()
+    raw = "un(usual:2) tone"
+    clean, char_spans = parse_weighted_prompt(raw)
+    assert clean == "unusual tone"
+    assert len(char_spans) == 1
+
+    stderr_capture = io.StringIO()
+    with contextlib.redirect_stderr(stderr_capture):
+        token_spans = compute_token_spans(clean, char_spans, tok, max_len=256)
+
+    assert token_spans == []
+    warning = stderr_capture.getvalue()
+    assert "skipping span" in warning
+    assert "usual" in warning
 
 
 def test_weight_one_is_a_bit_exact_noop():

--- a/optimized/mlx/scripts/test_prompt_weighting.py
+++ b/optimized/mlx/scripts/test_prompt_weighting.py
@@ -7,9 +7,12 @@ Run either way:
 import os
 import sys
 
+import numpy as np
+import sentencepiece as spm
+
 REPO = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, REPO)
-from prompt_weighting import parse_weighted_prompt
+from prompt_weighting import parse_weighted_prompt, compute_token_spans
 
 
 def test_no_weighted_spans():
@@ -62,6 +65,68 @@ def test_malformed_syntax_passes_through_untouched():
     clean, spans = parse_weighted_prompt(raw)
     assert clean == raw
     assert spans == []
+
+
+def _load_tokenizer():
+    """Load just the bundled SentencePiece tokenizer, no model weights —
+    matches how T5Gemma.from_npz stores it (models/defs/t5gemma_mlx.py),
+    without paying for the full transformer load in every test run."""
+    npz_path = os.path.join(REPO, "..", "models", "mlx", "t5gemma_f16.npz")
+    arrs = np.load(npz_path)
+    tok = spm.SentencePieceProcessor()
+    tok.LoadFromSerializedProto(arrs["TOKENIZER_MODEL"].tobytes())
+    return tok
+
+
+def test_boundaries_match_real_phrase_tokens():
+    tok = _load_tokenizer()
+    raw = "rigid mechanical grid pulse, (driving rhythmic pulse:2), cold synthetic timbre"
+    clean, char_spans = parse_weighted_prompt(raw)
+    token_spans = compute_token_spans(clean, char_spans, tok, max_len=256)
+    assert len(token_spans) == 1
+    start, end, weight = token_spans[0]
+    assert weight == 2.0
+    full_ids = tok.Encode(clean)
+    phrase = clean[char_spans[0][0]:char_spans[0][1]]
+    # the phrase appears mid-sentence, so it's preceded by a space in the
+    # full tokenization — re-tokenizing it WITH a leading space must give
+    # exactly the token IDs the computed boundaries slice out.
+    assert full_ids[start:end] == tok.Encode(" " + phrase)
+
+
+def test_boundaries_at_prompt_start_need_no_leading_space():
+    tok = _load_tokenizer()
+    raw = "(cold synthetic timbre:1.7), sparse texture"
+    clean, char_spans = parse_weighted_prompt(raw)
+    token_spans = compute_token_spans(clean, char_spans, tok, max_len=256)
+    start, end, weight = token_spans[0]
+    full_ids = tok.Encode(clean)
+    phrase = clean[char_spans[0][0]:char_spans[0][1]]
+    assert full_ids[start:end] == tok.Encode(phrase)
+
+
+def test_multiple_spans_all_resolve_correctly():
+    tok = _load_tokenizer()
+    raw = "(rhythm:2) and (silence:0.3) together"
+    clean, char_spans = parse_weighted_prompt(raw)
+    token_spans = compute_token_spans(clean, char_spans, tok, max_len=256)
+    assert len(token_spans) == 2
+    full_ids = tok.Encode(clean)
+    expected_phrases = ["rhythm", "silence"]
+    expected_leading_space = [False, True]  # "rhythm" is at position 0
+    for (start, end, weight), phrase, needs_space in zip(
+        token_spans, expected_phrases, expected_leading_space
+    ):
+        want = tok.Encode((" " if needs_space else "") + phrase)
+        assert full_ids[start:end] == want
+
+
+def test_span_beyond_max_len_is_dropped():
+    tok = _load_tokenizer()
+    raw = ("pulse " * 400) + "(rhythm:2) tail"
+    clean, char_spans = parse_weighted_prompt(raw)
+    token_spans = compute_token_spans(clean, char_spans, tok, max_len=256)
+    assert token_spans == []
 
 
 def _main():

--- a/optimized/mlx/scripts/test_prompt_weighting.py
+++ b/optimized/mlx/scripts/test_prompt_weighting.py
@@ -1,0 +1,82 @@
+"""Unit tests for prompt_weighting.py — SA3's (phrase:weight) prompt syntax.
+
+Run either way:
+    python scripts/test_prompt_weighting.py
+    pytest scripts/test_prompt_weighting.py
+"""
+import os
+import sys
+
+REPO = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, REPO)
+from prompt_weighting import parse_weighted_prompt
+
+
+def test_no_weighted_spans():
+    clean, spans = parse_weighted_prompt("rigid mechanical grid pulse")
+    assert clean == "rigid mechanical grid pulse"
+    assert spans == []
+
+
+def test_single_weighted_span():
+    clean, spans = parse_weighted_prompt("a (driving rhythmic pulse:2) in the mix")
+    assert clean == "a driving rhythmic pulse in the mix"
+    assert spans == [(2, 24, 2.0)]
+    assert clean[spans[0][0]:spans[0][1]] == "driving rhythmic pulse"
+
+
+def test_weighted_span_at_prompt_start():
+    clean, spans = parse_weighted_prompt("(cold synthetic timbre:1.7), sparse texture")
+    assert clean == "cold synthetic timbre, sparse texture"
+    assert spans == [(0, 21, 1.7)]
+    assert clean[spans[0][0]:spans[0][1]] == "cold synthetic timbre"
+
+
+def test_multiple_weighted_spans():
+    clean, spans = parse_weighted_prompt("(rhythm:2) and (silence:0.3) together")
+    assert clean == "rhythm and silence together"
+    phrases = [clean[s:e] for s, e, _ in spans]
+    weights = [w for _, _, w in spans]
+    assert phrases == ["rhythm", "silence"]
+    assert weights == [2.0, 0.3]
+
+
+def test_repeated_phrase_text_in_and_out_of_span():
+    clean, spans = parse_weighted_prompt("pulse and (pulse:2) again")
+    assert clean == "pulse and pulse again"
+    assert len(spans) == 1
+    s, e, w = spans[0]
+    assert clean[s:e] == "pulse"
+    assert w == 2.0
+    # must be the SECOND "pulse" (the weighted one), not the first
+    assert s == clean.index("pulse", 1)
+
+
+def test_negative_and_fractional_weights():
+    clean, spans = parse_weighted_prompt("(low end:-1) and (air:0.25)")
+    assert [w for _, _, w in spans] == [-1.0, 0.25]
+
+
+def test_malformed_syntax_passes_through_untouched():
+    raw = "(unclosed paren and (no weight) plain text"
+    clean, spans = parse_weighted_prompt(raw)
+    assert clean == raw
+    assert spans == []
+
+
+def _main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = []
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  FAIL {t.__name__}: {e}")
+            failed.append(t.__name__)
+    print("\n" + ("ALL PASS" if not failed else f"FAILURES: {failed}"))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/optimized/mlx/scripts/test_prompt_weighting.py
+++ b/optimized/mlx/scripts/test_prompt_weighting.py
@@ -7,12 +7,13 @@ Run either way:
 import os
 import sys
 
+import mlx.core as mx
 import numpy as np
 import sentencepiece as spm
 
 REPO = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, REPO)
-from prompt_weighting import parse_weighted_prompt, compute_token_spans
+from prompt_weighting import parse_weighted_prompt, compute_token_spans, apply_prompt_weights
 
 
 def test_no_weighted_spans():
@@ -157,6 +158,57 @@ def test_phrase_with_trailing_space_does_not_include_stray_whitespace_token():
         f"span tokens {span_tokens} should equal {expected_tokens} "
         f"(phrase with leading space, no trailing space)"
     )
+
+
+def test_weight_one_is_a_bit_exact_noop():
+    embeds = mx.array(np.random.default_rng(0).standard_normal((1, 6, 4)).astype(np.float32))
+    pe = mx.array(np.random.default_rng(1).standard_normal((4,)).astype(np.float32))
+    out = apply_prompt_weights(embeds, [(1, 3, 1.0)], pe)
+    assert np.array_equal(np.asarray(out), np.asarray(embeds))
+
+
+def test_empty_spans_is_a_bit_exact_noop():
+    embeds = mx.array(np.random.default_rng(0).standard_normal((1, 6, 4)).astype(np.float32))
+    pe = mx.array(np.random.default_rng(1).standard_normal((4,)).astype(np.float32))
+    out = apply_prompt_weights(embeds, [], pe)
+    assert np.array_equal(np.asarray(out), np.asarray(embeds))
+
+
+def test_weight_zero_collapses_span_to_padding_embedding():
+    embeds = mx.array(np.random.default_rng(0).standard_normal((1, 6, 4)).astype(np.float32))
+    pe = mx.array(np.random.default_rng(1).standard_normal((4,)).astype(np.float32))
+    out = np.asarray(apply_prompt_weights(embeds, [(2, 4, 0.0)], pe))
+    pe_np = np.asarray(pe)
+    for t in (2, 3):
+        assert np.allclose(out[0, t], pe_np, atol=1e-5)
+    # untouched positions are unchanged
+    embeds_np = np.asarray(embeds)
+    for t in (0, 1, 4, 5):
+        assert np.array_equal(out[0, t], embeds_np[0, t])
+
+
+def test_weight_extrapolates_linearly_past_plain_embedding():
+    embeds = mx.array(np.random.default_rng(0).standard_normal((1, 6, 4)).astype(np.float32))
+    pe = mx.array(np.random.default_rng(1).standard_normal((4,)).astype(np.float32))
+    out = np.asarray(apply_prompt_weights(embeds, [(0, 2, 2.0)], pe))
+    embeds_np = np.asarray(embeds)
+    pe_np = np.asarray(pe)
+    expected = pe_np + 2.0 * (embeds_np[0, 0] - pe_np)
+    assert np.allclose(out[0, 0], expected, atol=1e-5)
+
+
+def test_multiple_spans_do_not_interfere():
+    embeds = mx.array(np.random.default_rng(0).standard_normal((1, 6, 4)).astype(np.float32))
+    pe = mx.array(np.random.default_rng(1).standard_normal((4,)).astype(np.float32))
+    out = np.asarray(apply_prompt_weights(embeds, [(0, 1, 0.0), (4, 6, 3.0)], pe))
+    embeds_np = np.asarray(embeds)
+    pe_np = np.asarray(pe)
+    assert np.allclose(out[0, 0], pe_np, atol=1e-5)
+    for t in (1, 2, 3):
+        assert np.array_equal(out[0, t], embeds_np[0, t])
+    for t in (4, 5):
+        expected = pe_np + 3.0 * (embeds_np[0, t] - pe_np)
+        assert np.allclose(out[0, t], expected, atol=1e-5)
 
 
 def _main():


### PR DESCRIPTION
## What this is

I'm not a regular contributor here and I want to be upfront: I'm not
fully sure this is something the project wants, or whether it's the
right way to do it. It works on my machine and seemed useful enough to
share, so I'm opening this mostly to ask "is this interesting to you?"
rather than assuming it should be merged as-is. Happy to adjust or
close it if it's not a good fit.

## The idea

Stable Diffusion tools have had inline prompt-weighting syntax for a
while — writing `(some phrase:1.5)` makes that part of the prompt pull
harder on the output than plain text would, and `(some phrase:0.5)`
pulls it down. This PR adds the same idea to the MLX inference path
here (`optimized/mlx/scripts/sa3_mlx.py`), for both `--prompt` and
`--negative-prompt`.

`weight=1.0` is a no-op — verified byte-identical to not using the
syntax at all, same seed. Weights aren't clamped, so negative and
above-1 values both work (see "Things I'm less sure about" below).

## How it works, briefly

All of the actual logic lives in one new, self-contained file,
`optimized/mlx/scripts/prompt_weighting.py` — `sa3_mlx.py` only gets
two small call sites patched (parse the prompt before encoding it,
then apply the weighting to the resulting embeddings before they go
into the rest of the pipeline). The idea: parse out `(phrase:weight)`
groups first, tokenize the cleaned-up prompt once as normal, then work
out which token positions came from which phrase by comparing token
counts of successively longer prefixes of the text (rather than
searching for the phrase's tokens after the fact, which felt more
fragile). Each weighted span then gets pulled toward or away from the
model's own learned "empty" conditioning embedding, using the same
kind of interpolation other prompt-weighting implementations use
(instead of literally multiplying the embedding, which isn't well
behaved since the embedding space isn't centered at zero).

## Testing

- `optimized/mlx/scripts/test_prompt_weighting.py` — 18 unit tests
  covering the parsing, the token-span math (checked against the
  actual bundled tokenizer), and the reweighting formula.
- Real generations, not just unit tests: confirmed the no-op case is
  genuinely byte-identical output, and ran a bunch of side-by-side
  comparisons sweeping a phrase's weight up and down to see whether it
  does what it's supposed to (measured with basic spectral/energy
  metrics, not just "sounds right to me" — I don't fully trust my own
  ears on this kind of thing).
- `check_distortion.py`-style peak/true-peak checks came back clean
  across the weight range I tried, including fairly extreme values.

## Things I'm less sure about

- If a weighted phrase immediately follows another word with no space
  or punctuation before the `(` (like `word(phrase:2)`), the token
  boundary can land in the wrong place. This is a known limitation of
  this general approach (not specific to my implementation) — I made
  it fail loudly (a warning) instead of silently doing the wrong thing,
  but I haven't tried to actually fix the underlying alignment issue.
- Very large or very negative weights (I tried as far as ±5) don't
  necessarily keep moving the output in a straight line the further out
  you go — makes sense since you're extrapolating outside anything the
  model was trained on, but I don't have a strong intuition for where
  it stops being useful.
- The Gradio UI (`sa3_gradio.py`) doesn't get this feature — it has its
  own separate pipeline code that I didn't want to touch without being
  more confident this belongs here at all. I left a comment noting the
  gap rather than wiring it up.

Genuinely open to "this isn't a good direction for the project" as an
outcome here — figured it's easier to show working code and ask than
to guess in the abstract.